### PR TITLE
fix CI build because apparently cabal versions are no longer specifie…

### DIFF
--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -13,7 +13,7 @@ copyright:           (c) 2018 Least Authority TFA Gmbh
 category:            Network
 build-type:          Simple
 extra-source-files:  ChangeLog.md
-cabal-version:       >=2.2
+cabal-version:       2.0
 data-files:          wordlist.txt
 
 library


### PR DESCRIPTION
…d as a range

CI reports a failure:
  unexpected cabal-version higher than 2.2 cannot be specified as a range. See
  https://github.com/haskell/cabal/issues/4899
  expecting ".", "-", white space, "&&" or "||" >=2.2
  setup-Simple-Cabal-2.2.0.1-x86_64-linux-ghc-8.0.2: Failed parsing "./hwormhole.cabal".

This change also relaxes the lower bound to 2.0 instead of the very new 2.2 and see
how that goes.