### PR TITLE
check and abort connection if out of order packets are received

### DIFF
--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -81,6 +81,7 @@ test-suite hwormhole-tests
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:      base >=4.6 && <5
                     , aeson >=1.4 && <2
+                    , bytestring
                     , conduit
                     , binary
                     , binary-conduit

--- a/src/Transit/Internal/Crypto.hs
+++ b/src/Transit/Internal/Crypto.hs
@@ -5,6 +5,7 @@ module Transit.Internal.Crypto
   , CipherText
   , deriveKeyFromPurpose
   , Purpose(..)
+  , CryptoError(..)
   )
 where
 
@@ -21,20 +22,27 @@ import qualified Crypto.Saltine.Internal.ByteSizes as ByteSizes
 type PlainText = ByteString
 type CipherText = ByteString
 
+data CryptoError
+  = BadNonce Text
+  | CouldNotDecrypt Text
+  deriving (Eq, Show)
+
+instance Exception CryptoError
+
 -- | decrypt the bytestring representing ciphertext block with
 -- the given key. It is assumed that the ciphertext bytestring
 -- is nonce followed by the actual encrypted data.
-decrypt :: SecretBox.Key -> CipherText -> Either Text PlainText
+decrypt :: SecretBox.Key -> CipherText -> Either CryptoError (PlainText, SecretBox.Nonce)
 decrypt key ciphertext =
   -- extract nonce from ciphertext.
-  let (nonceBytes, ct) = BS.splitAt boxNonce ciphertext
+  let (nonceBytes, record) = BS.splitAt boxNonce ciphertext
       nonce = fromMaybe (panic "unable to decode nonce") $
               Saltine.decode nonceBytes
-      maybePlainText = SecretBox.secretboxOpen key nonce ct
+      maybePlainText = SecretBox.secretboxOpen key nonce record
   in
     case maybePlainText of
-      Just pt -> Right pt
-      Nothing -> Left "decryption error"
+      Just plaintext -> Right (plaintext, nonce)
+      Nothing -> Left (CouldNotDecrypt "SecretBox failed to open")
 
 -- | encrypt the given chunk with the given secretbox key and nonce.
 -- Saltine's nonce seem represented as a big endian bytestring.

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -152,7 +152,6 @@ data CommunicationError
   | OfferError Text
   | TransitError Text
   | Sha256SumError Text
-  | CouldNotDecrypt Text
   | UnknownPeerMessage Text
   deriving (Eq, Show)
 

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -45,8 +45,7 @@ import Transit.Internal.Network
   , buildDirectHints
   , closeConnection
   , sendBuffer
-  , recvBuffer
-  , CommunicationError(..))
+  , recvBuffer)
 import Transit.Internal.Crypto
   ( encrypt,
     decrypt,
@@ -205,7 +204,5 @@ receiveRecord ep key = do
     lenBytes <- recvBuffer ep 4
     let len = runGet getWord32be (BL.fromStrict lenBytes)
     encRecord <- recvBuffer ep (fromIntegral len)
-    case decrypt key encRecord of
-      Left s -> throwIO (CouldNotDecrypt s)
-      Right pt -> return pt
+    either throwIO (return . fst) (decrypt key encRecord)
 

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -12,7 +12,6 @@ import Crypto.Hash (SHA256(..))
 import Data.Conduit ((.|))
 import Data.ByteString.Builder(toLazyByteString, word32BE)
 import Data.Binary.Get (getWord32be, runGet)
-import Crypto.Saltine.Internal.ByteSizes (boxNonce)
 
 import qualified Crypto.Hash as Hash
 import qualified Conduit as C
@@ -24,8 +23,8 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Crypto.Saltine.Class as Saltine
 
-import Transit.Internal.Network (TCPEndpoint(..), CommunicationError(..))
-import Transit.Internal.Crypto (encrypt)
+import Transit.Internal.Network (TCPEndpoint(..))
+import Transit.Internal.Crypto (encrypt, decrypt, CryptoError(..))
 
 -- | Given the peer network socket and the file path to be sent, this Conduit
 -- pipeline reads the file, encrypts and send it over the network. A sha256
@@ -56,9 +55,9 @@ receivePipeline fp len (TCPEndpoint s) key =
     .| sha256PassThroughC `C.fuseBoth` C.sinkFileCautious fp
 
 encryptC :: Monad m => SecretBox.Key -> C.ConduitT ByteString ByteString m ()
-encryptC key = go Saltine.zero
+encryptC key = loop Saltine.zero
   where
-    go nonce = do
+    loop nonce = do
       b <- C.await
       case b of
         Nothing -> return ()
@@ -67,37 +66,40 @@ encryptC key = go Saltine.zero
               cipherTextSize = toLazyByteString (word32BE (fromIntegral (BS.length cipherText)))
           C.yield (toS cipherTextSize)
           C.yield cipherText
-          go (Saltine.nudge nonce)
+          loop (Saltine.nudge nonce)
 
 decryptC :: MonadIO m => SecretBox.Key -> C.ConduitT ByteString ByteString m ()
-decryptC key = loop
+decryptC key = loop Saltine.zero
   where
-    loop = do
+    loop :: MonadIO m => SecretBox.Nonce -> C.ConduitT ByteString ByteString m ()
+    loop seqNum = do
       b <- C.await
       case b of
         Nothing -> return ()
         Just bs -> do
-          let (nonceBytes, ciphertext) = BS.splitAt boxNonce bs
-              nonce = fromMaybe (panic "unable to decode nonce") $
-                Saltine.decode nonceBytes
-              maybePlainText = SecretBox.secretboxOpen key nonce ciphertext
-          case maybePlainText of
-            Just plaintext -> do
-              C.yield plaintext
-              loop
-            Nothing -> throwIO (CouldNotDecrypt "SecretBox failed to open")
+          case decrypt key bs of
+            Right (plainText, nonce) -> do
+              let seqNumLE = BS.reverse $ toS $ Saltine.encode seqNum
+                  seqNum' = fromMaybe (panic "nonce decode failed") $
+                            Saltine.decode (toS seqNumLE)
+              if nonce /= seqNum'
+                then throwIO (BadNonce "received out-of-order packets")
+                else do
+                C.yield plainText
+                loop (Saltine.nudge seqNum)
+            Left e -> throwIO e
 
 sha256PassThroughC :: (Monad m) => C.ConduitT ByteString ByteString m Text
-sha256PassThroughC = go $! Hash.hashInitWith SHA256
+sha256PassThroughC = loop $! Hash.hashInitWith SHA256
   where
-    go :: (Monad m) => Hash.Context SHA256 -> C.ConduitT ByteString ByteString m Text
-    go ctx = do
+    loop :: (Monad m) => Hash.Context SHA256 -> C.ConduitT ByteString ByteString m Text
+    loop ctx = do
       b <- C.await
       case b of
         Nothing -> return $! show (Hash.hashFinalize ctx)
         Just bs -> do
           C.yield bs
-          go $! Hash.hashUpdate ctx bs
+          loop $! Hash.hashUpdate ctx bs
 
 -- | The decryption conduit computation would succeed only if a complete
 -- bytestream that represents an encrypted block of data is given to it.

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -3,6 +3,8 @@ module Transit.Internal.Pipeline
   , receivePipeline
   -- * for tests
   , assembleRecordC
+  , decryptC
+  , encryptC
   )
 where
 

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -85,7 +85,7 @@ decryptC key = loop Saltine.zero
                   seqNum' = fromMaybe (panic "nonce decode failed") $
                             Saltine.decode (toS seqNumLE)
               if nonce /= seqNum'
-                then throwIO (BadNonce "received out-of-order packets")
+                then throwIO (BadNonce "received incorrect nonce")
                 else do
                 C.yield plainText
                 loop (Saltine.nudge seqNum)

--- a/tests/PipelineTests.hs
+++ b/tests/PipelineTests.hs
@@ -24,7 +24,7 @@ import Transit.Internal.Crypto (CryptoError)
 tests :: IO ()
 tests = hspec $ do
   describe "assembleRecordC tests" $ do
-    it "test with a small bytestring" $ do
+    it "tests assembleRecordC with a short bytestring input" $ do
       let str = "hello" :: ByteString
       xs <- liftIO $ C.runConduitRes $
             CSB.sourcePut (putChunk str)
@@ -34,7 +34,7 @@ tests = hspec $ do
       xs `shouldBe` (toS str)
 
   describe "decryptC tests" $ do
-    it "encryptC/decryptC round trip" $ do
+    it "tests a encryptC/decryptC round trip" $ do
       let key = fromMaybe (panic "cannot decode key") $
                 Saltine.decode ("0123456789abcdef0123456789abcdef" :: ByteString)
           plaintext = "foobar" :: ByteString
@@ -47,7 +47,7 @@ tests = hspec $ do
               .| CB.sinkLbs)
       xs `shouldBe` (toS plaintext)
 
-    it "decryptC with a forged sequence number" $ do
+    it "throws CryptoError when a wrong nonce is encountered" $ do
       -- create a packet with a non-zero nonce concatenated with
       -- random input. Feed it as a source into decryptC and feed
       -- output into a sinkLbs. This should throw a BadNonce

--- a/tests/PipelineTests.hs
+++ b/tests/PipelineTests.hs
@@ -3,35 +3,72 @@ module PipelineTests
   )
 where
 
-import Protolude
+import Protolude hiding (putByteString, Selector)
+
 import Test.Hspec
 import Conduit ((.|))
 
+import qualified Crypto.Saltine.Class as Saltine
+import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Conduit.Serialization.Binary as CSB
-import qualified Data.Text as T
+import qualified Data.ByteString as BS
 
-import Data.String (String)
 import Data.Binary (Put)
-import Data.Binary.Put (putStringUtf8, putWord32be)
+import Data.Binary.Put (putWord32be, putByteString)
 
 import Transit.Internal.Pipeline
+import Transit.Internal.Crypto (CryptoError)
 
 tests :: IO ()
 tests = hspec $ do
   describe "assembleRecordC tests" $ do
     it "test with a small bytestring" $ do
+      let str = "hello" :: ByteString
       xs <- liftIO $ C.runConduitRes $
             CSB.sourcePut (putChunk str)
             .| assembleRecordC
-            .| CB.isolate (T.length str)
+            .| CB.isolate (BS.length str)
             .| CB.sinkLbs
-      xs `shouldBe` "hello"
+      xs `shouldBe` (toS str)
+
+  describe "decryptC tests" $ do
+    it "encryptC/decryptC round trip" $ do
+      let key = fromMaybe (panic "cannot decode key") $
+                Saltine.decode ("0123456789abcdef0123456789abcdef" :: ByteString)
+          plaintext = "foobar" :: ByteString
+      xs <- liftIO (C.runConduitRes $
+              CSB.sourcePut (putByteString plaintext)
+              .| encryptC key
+              .| assembleRecordC
+              .| decryptC key
+              .| CB.isolate (BS.length plaintext)
+              .| CB.sinkLbs)
+      xs `shouldBe` (toS plaintext)
+
+    it "decryptC with a forged sequence number" $ do
+      -- create a packet with a non-zero nonce concatenated with
+      -- random input. Feed it as a source into decryptC and feed
+      -- output into a sinkLbs. This should throw a BadNonce
+      -- exception, as decryptC expects a nonce/sequence number of 0.
+      let nonce = Saltine.nudge Saltine.zero :: SecretBox.Nonce
+          key = fromMaybe (panic "cannot decode key") $
+                Saltine.decode ("0123456789abcdef0123456789abcdef" :: ByteString)
+          nonceBytes = Saltine.encode nonce
+          plaintext = "foobar" :: ByteString
+          packet = nonceBytes <> plaintext
+      liftIO (C.runConduitRes $
+              CSB.sourcePut (putByteString packet)
+              .| decryptC key
+              .| CB.isolate (BS.length packet)
+              .| CB.sinkLbs)
+        `shouldThrow` cryptoError
         where
-          str = "hello"
-          putChunk :: Text -> Put
+          putChunk :: ByteString -> Put
           putChunk s = do
-            let strlen = T.length s
+            let strlen = BS.length s
             putWord32be (fromIntegral @Int strlen)
-            putStringUtf8 (toS @Text @String s)
+            putByteString s
+          cryptoError :: Selector CryptoError
+          cryptoError = const True


### PR DESCRIPTION
Addresses #20. Refactor the decrypt and decryptC code for better handling
of out-of-order packets. decryptC was reimplementing decrypt, which didn't seem like the right thing to do, making maintenance hard. Instead, now decryptC will make use of decrypt.

The `fromMaybe` and other partial functions should go away because they render our Exception mechanisms useless. These will be addressed across the code in another separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/34)
<!-- Reviewable:end -->
