### PR TITLE
rename MsgAck -> MessageAck

### DIFF
--- a/src/Transit/Internal/Messages.hs
+++ b/src/Transit/Internal/Messages.hs
@@ -81,7 +81,7 @@ instance FromJSON ConnectionHint where
                                   _ -> name }
 
 data Ack = FileAck Text
-         | MsgAck Text
+         | MessageAck Text
          deriving (Eq, Show, Generic)
 
 instance ToJSON Ack where

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -35,7 +35,7 @@ import System.FilePath (takeFileName)
 import Transit.Internal.Messages
   ( TransitMsg(..)
   , TransitAck(..)
-  , Ack( FileAck, MsgAck )
+  , Ack( FileAck, MessageAck )
   , Ability(..)
   , AbilityV1(..)
   , ConnectionHint)
@@ -117,7 +117,7 @@ senderOfferExchange conn path = do
     Right (Error errstr) -> return $ Left (toS errstr)
     Right (Answer (FileAck msg)) | msg == "ok" -> return (Right ())
                                  | otherwise -> return $ Left "Did not get file ack. Exiting"
-    Right (Answer (MsgAck _)) -> return $ Left "expected file ack, got message ack instead"
+    Right (Answer (MessageAck _)) -> return $ Left "expected file ack, got message ack instead"
     Right (Transit _ _) -> return $ Left "unexpected transit message"
   where
     sendOffer :: IO ()

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -50,7 +50,7 @@ connectionHintGen = Gen.choice
 ackGen :: MonadGen m => m Ack
 ackGen = Gen.choice
   [ FileAck <$> Gen.text (Range.linear 0 100) Gen.ascii
-  , MsgAck <$> Gen.text (Range.linear 0 100) Gen.ascii
+  , MessageAck <$> Gen.text (Range.linear 0 100) Gen.ascii
   ]
 
 transitMsgGen :: MonadGen m => m TransitMsg


### PR DESCRIPTION
Because of the way we decode/encode JSON, this would have erroneously
encoded/decoded into "msg_ack" where as we want it to be "message_ack".

Fix a failed test compilation due to MsgAck renaming.