### PR TITLE
Get rid of allocateTcpPort function

### DIFF
--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -20,7 +20,7 @@ import Network.Socket (socketPort)
 import qualified MagicWormhole
 
 import Transit.Internal.Network
-  ( allocateTcpPort
+  ( tcpListener
   , buildDirectHints
   , startServer
   , startClient

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -15,6 +15,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
 import qualified Conduit as C
 
+import Network.Socket (socketPort)
+
 import qualified MagicWormhole
 
 import Transit.Internal.Network
@@ -85,8 +87,9 @@ send session appid password printHelpFn tfd = do
               Right s -> throwIO (TransitError (show s))
           TFile filepath -> do
             -- exchange abilities
-            portnum <- allocateTcpPort
-            withAsync (startServer portnum) $ \asyncServer -> do
+            sock' <- tcpListener
+            portnum <- socketPort sock'
+            withAsync (startServer sock') $ \asyncServer -> do
               transitResp <- transitExchange conn portnum
               case transitResp of
                 Left s -> throwIO (TransitError s)
@@ -151,9 +154,10 @@ receive session appid code = do
               Left err -> throwIO (TransitError (toS err))
               Right (Transit peerAbilities peerHints) -> do
                 let abilities' = [Ability DirectTcpV1]
-                portnum <- allocateTcpPort
+                s <- tcpListener
+                portnum <- socketPort s
                 hints' <- buildDirectHints portnum
-                withAsync (startServer portnum) $ \asyncServer -> do
+                withAsync (startServer s) $ \asyncServer -> do
                   sendTransitMsg conn abilities' hints'
                   -- now expect an offer message
                   offerMsg <- receiveWormholeMessage conn

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -2,15 +2,20 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE FlexibleContexts #-}
 module Transit.Internal.Network
-  ( tcpListener
-  , buildDirectHints
+  (
+    -- * build direct hints from port number and the interfaces on the host.
+    buildDirectHints
+    -- * low level bytestring buffer send/receive over a socket
   , sendBuffer
   , recvBuffer
+    -- * TCP Endpoint
   , closeConnection
   , TCPEndpoint(..)
-  , PortNumber
+    -- * TCP Listener that listens on a random port, Server and Client
+  , tcpListener
   , startServer
   , startClient
+    -- * Error
   , CommunicationError(..)
   ) where
 

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -31,6 +31,7 @@ import Data.Text (toLower)
 import System.Posix.Types (FileOffset)
 import System.PosixCompat.Files (getFileStatus, fileSize)
 import System.FilePath (takeFileName)
+import Network.Socket (PortNumber)
 
 import Transit.Internal.Messages
   ( TransitMsg(..)
@@ -41,7 +42,6 @@ import Transit.Internal.Messages
   , ConnectionHint)
 import Transit.Internal.Network
   ( TCPEndpoint(..)
-  , PortNumber
   , buildDirectHints
   , closeConnection
   , sendBuffer


### PR DESCRIPTION
The problem is mentioned in issue #18. We implement the suggestion 2 outlines in this Tahoe-LAFS ticket: https://tahoe-lafs.org/trac/tahoe-lafs/ticket/2787. We create a bind and start listening and return the socket and later use it to start a tcp server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/37)
<!-- Reviewable:end -->
