### PR TITLE
More refactoring for supporting transit relay servers

### DIFF
--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -162,6 +162,8 @@ receive session appid code = do
           Right (MagicWormhole.File _ _) -> do
             Transit.sendMessageAck conn "not_ok"
             throwIO (Transit.ConnectionError "did not expect a file offer")
+          Right (MagicWormhole.Directory _ _ _ _ _) ->
+            throwIO (Transit.UnknownPeerMessage "directory offer is not supported")
           -- ok, we received the Transit Message, send back a transit message
           Left received ->
             case (Transit.decodeTransitMsg (toS received)) of

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -20,12 +20,17 @@
 --
 module Transit
   ( FileTransfer.sendFile
-  , FileTransfer.receive
+  , FileTransfer.receiveFile
   , FileTransfer.MessageType(..)
   , Peer.sendOffer
+  , Peer.receiveOffer
   , Peer.receiveMessageAck
+  , Peer.sendMessageAck
+  , Peer.decodeTransitMsg
+  , Network.CommunicationError(..)
   )
 where
 
 import qualified Transit.Internal.FileTransfer as FileTransfer
 import qualified Transit.Internal.Peer as Peer
+import qualified Transit.Internal.Network as Network

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -19,11 +19,13 @@
 -- so that each message is encrypted using NaCl SecretBox.
 --
 module Transit
-  ( FileTransfer.send
+  ( FileTransfer.sendFile
   , FileTransfer.receive
   , FileTransfer.MessageType(..)
+  , Peer.sendOffer
+  , Peer.receiveMessageAck
   )
 where
 
 import qualified Transit.Internal.FileTransfer as FileTransfer
-
+import qualified Transit.Internal.Peer as Peer

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -25,8 +25,8 @@ import Transit.Internal.Network
   , closeConnection
   , CommunicationError(..))
 import Transit.Internal.Peer
-  ( transitExchange
-  , senderOfferExchange
+  ( senderTransitExchange
+  , senderFileOfferExchange
   , makeSenderRecordKey
   , makeReceiverRecordKey
   , senderHandshakeExchange

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -174,9 +174,10 @@ receive session appid code = do
             throwIO (ConnectionError "did not expect a directory offer")
           -- ok, we received the Transit Message, send back a transit message
           Left received ->
-            case Aeson.eitherDecode (toS received) of
-              Left err -> throwIO (TransitError (toS err))
+            case (decodeTransitMsg (toS received)) of
+              Left e -> throwIO e
               Right transitMsg@(Transit _ _) ->
                 receiveFile conn appid transitMsg
-              Right _ -> throwIO (UnknownPeerMessage "Could not decode message")
+              Right e ->
+                throwIO (UnknownPeerMessage (show e))
     )

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -63,6 +63,54 @@ transitPurpose (MagicWormhole.AppID appID) = toS appID <> "/transit-key"
 -- the wormhole securely. The receiver, on successfully receiving the file, would compute
 -- a sha256 sum of the encrypted file and sends it across to the sender, along with an
 -- acknowledgement, which the sender can verify.
+sendFile :: MagicWormhole.EncryptedConnection -> MagicWormhole.AppID -> FilePath -> IO ()
+sendFile conn appid filepath = do
+  -- exchange abilities
+  sock' <- tcpListener
+  portnum <- socketPort sock'
+  withAsync (startServer sock') $ \asyncServer -> do
+    transitResp <- transitExchange conn portnum
+    case transitResp of
+      Left s -> throwIO (TransitError s)
+      Right (Transit peerAbilities peerHints) -> do
+        -- send offer for the file
+        offerResp <- senderOfferExchange conn filepath
+        case offerResp of
+          Left s -> throwIO (OfferError s)
+          Right _ ->
+            withAsync (startClient peerHints) $ \asyncClient -> do
+            ep <- waitAny [asyncServer, asyncClient]
+            let endpoint = snd ep
+            -- 0. derive transit key
+            let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
+            -- 1. create record keys
+                maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
+                                  <*> makeReceiverRecordKey transitKey
+            case maybeRecordKeys of
+              Nothing -> throwIO (TransitError "could not create record keys")
+              Just (sRecordKey, rRecordKey) -> do
+                -- 2. handshakeExchange
+                senderHandshakeExchange endpoint transitKey
+                -- 3. send encrypted chunks of N bytes to the peer
+                (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
+                -- 4. read a record that should contain the transit Ack.
+                --    If ack is not ok or the sha256sum is incorrect, flag an error.
+                rxAckMsg <- receiveAckMessage endpoint rRecordKey
+                closeConnection endpoint
+                case rxAckMsg of
+                  Right rxSha256Hash ->
+                    when (txSha256Hash /= rxSha256Hash) $
+                    throwIO (Sha256SumError "sha256 mismatch")
+                  Left e -> throwIO (ConnectionError e)
+      Right _ -> throwIO (ConnectionError "error sending transit message")
+
+
+-- | Given the magic-wormhole session, appid, password, a function to print a helpful message
+-- on the command the receiver needs to type (simplest would be just a `putStrLn`) and the
+-- path on the disk of the sender of the file that needs to be sent, `sendFile` sends it via
+-- the wormhole securely. The receiver, on successfully receiving the file, would compute
+-- a sha256 sum of the encrypted file and sends it across to the sender, along with an
+-- acknowledgement, which the sender can verify.
 send :: MagicWormhole.Session -> MagicWormhole.AppID -> Password -> (Text -> IO ()) -> MessageType -> IO ()
 send session appid password printHelpFn tfd = do
   -- first establish a wormhole session with the receiver and
@@ -85,46 +133,52 @@ send session appid password printHelpFn tfd = do
               Right (Answer (MessageAck msg')) | msg' == "ok" -> return ()
                                                | otherwise -> throwIO (TransitError "Message ack failed")
               Right s -> throwIO (TransitError (show s))
-          TFile filepath -> do
-            -- exchange abilities
-            sock' <- tcpListener
-            portnum <- socketPort sock'
-            withAsync (startServer sock') $ \asyncServer -> do
-              transitResp <- transitExchange conn portnum
-              case transitResp of
-                Left s -> throwIO (TransitError s)
-                Right (Transit peerAbilities peerHints) -> do
-                  -- send offer for the file
-                  offerResp <- senderOfferExchange conn filepath
-                  case offerResp of
-                    Left s -> throwIO (OfferError s)
-                    Right _ ->
-                      withAsync (startClient peerHints) $ \asyncClient -> do
-                        ep <- waitAny [asyncServer, asyncClient]
-                        let endpoint = snd ep
-                        -- 0. derive transit key
-                        let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
-                        -- 1. create record keys
-                            maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
-                                              <*> makeReceiverRecordKey transitKey
-                        case maybeRecordKeys of
-                          Nothing -> throwIO (TransitError "could not create record keys")
-                          Just (sRecordKey, rRecordKey) -> do
-                            -- 2. handshakeExchange
-                            senderHandshakeExchange endpoint transitKey
-                            -- 3. send encrypted chunks of N bytes to the peer
-                            (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
-                            -- 4. read a record that should contain the transit Ack.
-                            --    If ack is not ok or the sha256sum is incorrect, flag an error.
-                            rxAckMsg <- receiveAckMessage endpoint rRecordKey
-                            closeConnection endpoint
-                            case rxAckMsg of
-                              Right rxSha256Hash ->
-                                when (txSha256Hash /= rxSha256Hash) $
-                                throwIO (Sha256SumError "sha256 mismatch")
-                              Left e -> throwIO (ConnectionError e)
-                Right _ -> throwIO (ConnectionError "error sending transit message")
+          TFile filepath -> sendFile conn appid filepath
     )
+
+receiveFile :: MagicWormhole.EncryptedConnection -> MagicWormhole.AppID -> TransitMsg -> IO ()
+receiveFile conn appid (Transit peerAbilities peerHints) = do
+  let abilities' = [Ability DirectTcpV1]
+  s <- tcpListener
+  portnum <- socketPort s
+  hints' <- buildDirectHints portnum
+  withAsync (startServer s) $ \asyncServer -> do
+    sendTransitMsg conn abilities' hints'
+    -- now expect an offer message
+    offerMsg <- receiveWormholeMessage conn
+    case Aeson.eitherDecode (toS offerMsg) of
+      Left err -> throwIO (OfferError $ "unable to decode offer msg: " <> toS err)
+      Right (MagicWormhole.File name size) -> do
+        -- TODO: if the file already exist in the current dir, abort
+        -- send an answer message with file_ack.
+        let ans = Answer (FileAck "ok")
+        sendWormholeMessage conn (Aeson.encode ans)
+        -- runTransitProtocol peerAbilities peerHints asyncServer
+        withAsync (startClient peerHints) $ \asyncClient -> do
+          ep <- waitAny [asyncServer, asyncClient]
+          let endpoint = snd ep
+          -- 0. derive transit key
+          let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
+          -- 1. handshakeExchange
+          receiverHandshakeExchange endpoint transitKey
+          -- 2. create sender/receiver record key, sender record key
+          --    for decrypting incoming records, receiver record key
+          --    for sending the file_ack back at the end.
+          let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
+                                <*> makeReceiverRecordKey transitKey
+          case maybeRecordKeys of
+            Nothing -> throwIO (TransitError "could not create record keys")
+            Just (sRecordKey, rRecordKey) -> do
+              -- 3. receive and decrypt records (length followed by length
+              --    sized packets). Also keep track of decrypted size in
+              --    order to know when to send the file ack at the end.
+              (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
+              TIO.putStrLn (show rxSha256Sum)
+              sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
+              -- close the connection
+              closeConnection endpoint
+      Right _ -> throwIO (UnknownPeerMessage "Could not decode message")
+receiveFile _ _ _ = throwIO (UnknownPeerMessage "Could not recognize the message")
 
 -- | receive a text message or file from the wormhole peer.
 receive :: MagicWormhole.Session -> MagicWormhole.AppID -> Text -> IO ()
@@ -155,48 +209,7 @@ receive session appid code = do
           Left _ ->
             case Aeson.eitherDecode (toS received) of
               Left err -> throwIO (TransitError (toS err))
-              Right (Transit peerAbilities peerHints) -> do
-                let abilities' = [Ability DirectTcpV1]
-                s <- tcpListener
-                portnum <- socketPort s
-                hints' <- buildDirectHints portnum
-                withAsync (startServer s) $ \asyncServer -> do
-                  sendTransitMsg conn abilities' hints'
-                  -- now expect an offer message
-                  offerMsg <- receiveWormholeMessage conn
-                  case Aeson.eitherDecode (toS offerMsg) of
-                    Left err -> throwIO (OfferError $ "unable to decode offer msg: " <> toS err)
-                    Right (MagicWormhole.File name size) -> do
-                      -- TODO: if the file already exist in the current dir, abort
-                      -- send an answer message with file_ack.
-                      let ans = Answer (FileAck "ok")
-                      sendWormholeMessage conn (Aeson.encode ans)
-                      -- runTransitProtocol peerAbilities peerHints asyncServer
-                      withAsync (startClient peerHints) $ \asyncClient -> do
-                        ep <- waitAny [asyncServer, asyncClient]
-                        let endpoint = snd ep
-                        -- 0. derive transit key
-                        let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
-                        -- 1. handshakeExchange
-                        receiverHandshakeExchange endpoint transitKey
-                        -- 2. create sender/receiver record key, sender record key
-                        --    for decrypting incoming records, receiver record key
-                        --    for sending the file_ack back at the end.
-                        let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
-                                              <*> makeReceiverRecordKey transitKey
-                        case maybeRecordKeys of
-                          Nothing -> throwIO (TransitError "could not create record keys")
-                          Just (sRecordKey, rRecordKey) -> do
-                            -- 3. receive and decrypt records (length followed by length
-                            --    sized packets). Also keep track of decrypted size in
-                            --    order to know when to send the file ack at the end.
-                            (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
-                            TIO.putStrLn (show rxSha256Sum)
-                            sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
-                            -- close the connection
-                            closeConnection endpoint
-
-                    Right (MagicWormhole.Directory _ _ _ _ _) -> throwIO (UnknownPeerMessage "Directory offers are not supported yet")
-                    Right _ -> throwIO (UnknownPeerMessage "Could not decode message")
+              Right transitMsg@(Transit _ _) ->
+                receiveFile conn appid transitMsg
               Right _ -> throwIO (UnknownPeerMessage "Could not decode message")
     )

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -67,7 +67,7 @@ sendFile conn appid filepath = do
   sock' <- tcpListener
   portnum <- socketPort sock'
   withAsync (startServer sock') $ \asyncServer -> do
-    transitResp <- transitExchange conn portnum
+    transitResp <- senderTransitExchange conn portnum
     case transitResp of
       Left s -> throwIO (TransitError s)
       Right (Transit peerAbilities peerHints) -> do

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -14,6 +14,7 @@ module Transit.Internal.Peer
   , senderHandshakeExchange
   , receiverHandshakeExchange
   , sendTransitMsg
+  , decodeTransitMsg
   , sendGoodAckMessage
   , receiveAckMessage
   , receiveWormholeMessage
@@ -117,9 +118,14 @@ sendTransitMsg conn abilities' hints' = do
   -- create transit message
   let txTransitMsg = Transit abilities' hints'
   let encodedTransitMsg = toS (encode txTransitMsg)
-
   -- send the transit message (dictionary with key as "transit" and value as abilities)
   MagicWormhole.sendMessage conn (MagicWormhole.PlainText encodedTransitMsg)
+
+decodeTransitMsg :: ByteString -> Either CommunicationError TransitMsg
+decodeTransitMsg received =
+  case eitherDecode (toS received) of
+    Right transitMsg -> Right transitMsg
+    Left err -> Left $ TransitError (toS err)
 
 sendOffer :: MagicWormhole.EncryptedConnection -> MagicWormhole.Offer -> IO ()
 sendOffer conn offer =

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -51,7 +51,8 @@ import Transit.Internal.Network
   , buildDirectHints
   , closeConnection
   , sendBuffer
-  , recvBuffer)
+  , recvBuffer
+  , CommunicationError(..))
 import Transit.Internal.Crypto
   ( encrypt,
     decrypt,

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -140,6 +140,7 @@ receiveOffer conn = do
   case eitherDecode (toS received) of
     Right msg@(MagicWormhole.Message _) -> return $ Right msg
     Right file@(MagicWormhole.File _ _) -> return $ Right file
+    Right dir@(MagicWormhole.Directory _ _ _ _ _) -> return $ Right dir
     Left _ -> return $ Left received
 
 receiveMessageAck :: MagicWormhole.EncryptedConnection -> IO ()

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -5,7 +5,7 @@ module Transit.Internal.Peer
   , makeSenderRecordKey
   , makeReceiverRecordKey
   , makeSenderRelayHandshake
-  , transitExchange
+  , senderTransitExchange
   , senderFileOfferExchange
   , sendOffer
   , receiveOffer
@@ -96,8 +96,8 @@ makeReceiverRecordKey key =
 -- |'transitExchange' exchanges transit message with the peer.
 -- Sender sends a transit message with its abilities and hints.
 -- Receiver sends either another Transit message or an Error message.
-transitExchange :: MagicWormhole.EncryptedConnection -> PortNumber -> IO (Either Text TransitMsg)
-transitExchange conn portnum = do
+senderTransitExchange :: MagicWormhole.EncryptedConnection -> PortNumber -> IO (Either Text TransitMsg)
+senderTransitExchange conn portnum = do
   let abilities' = [Ability DirectTcpV1]
   hints' <- buildDirectHints portnum
   (_, rxMsg) <- concurrently (sendTransitMsg conn abilities' hints') receiveTransitMsg

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -26,7 +26,7 @@ import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Crypto.Saltine.Class as Saltine
 
 import Transit.Internal.Network (TCPEndpoint(..))
-import Transit.Internal.Crypto (encrypt, decrypt, CryptoError(..))
+import Transit.Internal.Crypto (encrypt, decrypt, CryptoError(..), PlainText(..), CipherText(..))
 
 -- | Given the peer network socket and the file path to be sent, this Conduit
 -- pipeline reads the file, encrypts and send it over the network. A sha256
@@ -64,9 +64,9 @@ encryptC key = loop Saltine.zero
       case b of
         Nothing -> return ()
         Just chunk -> do
-          let cipherText = encrypt key nonce chunk
+          let cipherText = encrypt key nonce (PlainText chunk)
           case cipherText of
-            Right cipherText' -> do
+            Right (CipherText cipherText') -> do
               let cipherTextSize = toLazyByteString (word32BE (fromIntegral (BS.length cipherText')))
               C.yield (toS cipherTextSize)
               C.yield cipherText'
@@ -82,8 +82,8 @@ decryptC key = loop Saltine.zero
       case b of
         Nothing -> return ()
         Just bs -> do
-          case decrypt key bs of
-            Right (plainText, nonce) -> do
+          case decrypt key (CipherText bs) of
+            Right (PlainText plainText, nonce) -> do
               let seqNumLE = BS.reverse $ toS $ Saltine.encode seqNum
                   seqNum' = Saltine.decode (toS seqNumLE)
               if Just nonce /= seqNum'


### PR DESCRIPTION
`send` and `receive` function in `FileTransfer` module is doing too much, so split them. Also move part of the split function out of the library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/39)
<!-- Reviewable:end -->
