### PR TITLE
Better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,8 @@ There is a `--help` command. It works for subcommands as well.
 
 ## What works at the moment
 
-- Message send and receive
+- Message send and receive via direct or relay hints, interoperable with Brian's python client.
 - Completion support for typing in the code
-- File sending to the Python `wormhole` client
 
 ## What's next?
 

--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -160,6 +160,7 @@ receive session transitserver appid code = do
         someOffer <- Transit.receiveOffer conn
         case someOffer of
           Right (MagicWormhole.Message message) -> do
+            TIO.putStrLn message
             result <- try (Transit.sendMessageAck conn "ok") :: IO (Either IOError ())
             return $ bimap (const (Transit.ConnectionError "sending the ack message failed")) identity result
           Right (MagicWormhole.File _ _) -> do

--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -162,16 +162,16 @@ receive session transitserver appid code = do
           Right (MagicWormhole.Message message) -> do
             TIO.putStrLn message
             result <- try (Transit.sendMessageAck conn "ok") :: IO (Either IOError ())
-            return $ bimap (const (Transit.GeneralError (Transit.ConnectionError "sending the ack message failed"))) identity result
+            return $ bimap (const (Transit.NetworkError (Transit.ConnectionError "sending the ack message failed"))) identity result
           Right (MagicWormhole.File _ _) -> do
             Transit.sendMessageAck conn "not_ok"
-            return $ Left (Transit.GeneralError (Transit.ConnectionError "did not expect a file offer"))
+            return $ Left (Transit.NetworkError (Transit.ConnectionError "did not expect a file offer"))
           Right (MagicWormhole.Directory _ _ _ _ _) ->
-            return $ Left (Transit.GeneralError (Transit.UnknownPeerMessage "directory offer is not supported"))
+            return $ Left (Transit.NetworkError (Transit.UnknownPeerMessage "directory offer is not supported"))
           -- ok, we received the Transit Message, send back a transit message
           Left received ->
             case (Transit.decodeTransitMsg (toS received)) of
-              Left e -> return $ Left (Transit.GeneralError e)
+              Left e -> return $ Left (Transit.NetworkError e)
               Right transitMsg ->
                 Transit.receiveFile conn transitserver appid transitMsg
     )

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   hs-source-dirs:      src
   exposed-modules:     Transit
+                     , Transit.Internal.Errors
                      , Transit.Internal.FileTransfer
                      , Transit.Internal.Network
                      , Transit.Internal.Peer

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -27,7 +27,7 @@ module Transit
   , Peer.receiveMessageAck
   , Peer.sendMessageAck
   , Peer.decodeTransitMsg
-  , Network.CommunicationError(..)
+  , Errors.CommunicationError(..)
   , Network.parseTransitRelayUri
   , Network.RelayEndpoint(..)
   )
@@ -36,3 +36,4 @@ where
 import qualified Transit.Internal.FileTransfer as FileTransfer
 import qualified Transit.Internal.Peer as Peer
 import qualified Transit.Internal.Network as Network
+import qualified Transit.Internal.Errors as Errors

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -27,9 +27,11 @@ module Transit
   , Peer.receiveMessageAck
   , Peer.sendMessageAck
   , Peer.decodeTransitMsg
-  , Errors.CommunicationError(..)
+  , Errors.Error(..)
+  , Errors.liftEitherCommError
   , Network.parseTransitRelayUri
   , Network.RelayEndpoint(..)
+  , Network.CommunicationError(..)
   )
 where
 

--- a/src/Transit/Internal/Errors.hs
+++ b/src/Transit/Internal/Errors.hs
@@ -14,11 +14,11 @@ import qualified Transit.Internal.Crypto as C
 import qualified Transit.Internal.Peer as P
 
 data Error = CipherError C.CryptoError
-           | GeneralError N.CommunicationError
+           | NetworkError N.CommunicationError
            | HandshakeError P.InvalidHandshake
            deriving (Show)
 
 instance E.Exception Error
 
 liftEitherCommError :: Either N.CommunicationError a -> Either Error a
-liftEitherCommError = first GeneralError
+liftEitherCommError = first NetworkError

--- a/src/Transit/Internal/Errors.hs
+++ b/src/Transit/Internal/Errors.hs
@@ -1,0 +1,28 @@
+module Transit.Internal.Errors
+  (
+    -- * Error
+    CommunicationError(..)
+  )
+where
+
+import Protolude
+
+data CommunicationError
+  = ConnectionError Text
+  -- ^ We could not establish a socket connection.
+  | OfferError Text
+  -- ^ Clients could not exchange offer message.
+  | TransitError Text
+  -- ^ There was an error in transit protocol exchanges.
+  | Sha256SumError Text
+  -- ^ Sender got back a wrong sha256sum from the receiver.
+  | UnknownPeerMessage Text
+  -- ^ We could not identify the message from peer.
+  | BadNonce Text
+  -- ^ The nonce value in the received message is invalid.
+  | CouldNotDecrypt Text
+  -- ^ We could not decrypt the incoming encrypted record.
+  deriving (Eq, Show)
+
+instance Exception CommunicationError
+

--- a/src/Transit/Internal/Errors.hs
+++ b/src/Transit/Internal/Errors.hs
@@ -1,28 +1,24 @@
 module Transit.Internal.Errors
-  (
+  ( liftEitherCommError
     -- * Error
-    CommunicationError(..)
+  , Error(..)
   )
 where
 
 import Protolude
 
-data CommunicationError
-  = ConnectionError Text
-  -- ^ We could not establish a socket connection.
-  | OfferError Text
-  -- ^ Clients could not exchange offer message.
-  | TransitError Text
-  -- ^ There was an error in transit protocol exchanges.
-  | Sha256SumError Text
-  -- ^ Sender got back a wrong sha256sum from the receiver.
-  | UnknownPeerMessage Text
-  -- ^ We could not identify the message from peer.
-  | BadNonce Text
-  -- ^ The nonce value in the received message is invalid.
-  | CouldNotDecrypt Text
-  -- ^ We could not decrypt the incoming encrypted record.
-  deriving (Eq, Show)
+import qualified Control.Exception as E
 
-instance Exception CommunicationError
+import qualified Transit.Internal.Network as N
+import qualified Transit.Internal.Crypto as C
+import qualified Transit.Internal.Peer as P
 
+data Error = CipherError C.CryptoError
+           | GeneralError N.CommunicationError
+           | HandshakeError P.InvalidHandshake
+           deriving (Show)
+
+instance E.Exception Error
+
+liftEitherCommError :: Either N.CommunicationError a -> Either Error a
+liftEitherCommError = first GeneralError

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -25,8 +25,9 @@ import Transit.Internal.Network
   , startServer
   , startClient
   , closeConnection
-  , RelayEndpoint
-  , CommunicationError(..))
+  , RelayEndpoint)
+
+import Transit.Internal.Errors(CommunicationError(..))
 
 import Transit.Internal.Peer
   ( makeSenderRecordKey

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -66,7 +66,7 @@ transitPurpose (MagicWormhole.AppID appID) = toS appID <> "/transit-key"
 -- the wormhole securely. The receiver, on successfully receiving the file, would compute
 -- a sha256 sum of the encrypted file and sends it across to the sender, along with an
 -- acknowledgement, which the sender can verify.
-sendFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> FilePath -> IO ()
+sendFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> FilePath -> IO (Either CommunicationError ())
 sendFile conn transitserver appid filepath = do
   -- exchange abilities
   sock' <- tcpListener
@@ -77,44 +77,48 @@ sendFile conn transitserver appid filepath = do
     let ourRelayHints = buildRelayHints transitserver
     transitResp <- senderTransitExchange conn (Set.toList ourHints)
     case transitResp of
-      Left s -> throwIO (TransitError s)
+      Left s -> return $ Left (TransitError s)
       Right (Transit peerAbilities peerHints) -> do
         -- send offer for the file
         offerResp <- senderFileOfferExchange conn filepath
         case offerResp of
-          Left s -> throwIO (OfferError s)
+          Left s -> return (Left (OfferError s))
           Right _ -> do
             -- combine our relay hints with peer's direct and relay hints
             let allHints = Set.toList $ ourRelayHints <> peerHints
             withAsync (startClient allHints) $ \asyncClient -> do
               ep <- waitAny [asyncServer, asyncClient]
-              let endpoint = snd ep
-              -- 0. derive transit key
-              let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
-              -- 1. create record keys
-                  maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
-                                    <*> makeReceiverRecordKey transitKey
-              case maybeRecordKeys of
-                Nothing -> throwIO (TransitError "could not create record keys")
-                Just (sRecordKey, rRecordKey) -> do
-                  -- 2. handshakeExchange
-                  senderHandshakeExchange endpoint transitKey side
+              let endpoint' = snd ep
+              case endpoint' of
+                Left e -> return (Left e)
+                Right endpoint -> do
+                  -- 0. derive transit key
+                  let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
+                  -- 1. create record keys
+                      maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
+                                        <*> makeReceiverRecordKey transitKey
+                  case maybeRecordKeys of
+                    Nothing -> return (Left (TransitError "could not create record keys"))
+                    Just (sRecordKey, rRecordKey) -> do
+                      -- 2. handshakeExchange
+                      senderHandshakeExchange endpoint transitKey side
 
-                  -- 3. send encrypted chunks of N bytes to the peer
-                  (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
-                  -- 4. read a record that should contain the transit Ack.
-                  --    If ack is not ok or the sha256sum is incorrect, flag an error.
-                  rxAckMsg <- receiveAckMessage endpoint rRecordKey
-                  closeConnection endpoint
-                  case rxAckMsg of
-                    Right rxSha256Hash ->
-                      when (txSha256Hash /= rxSha256Hash) $
-                      throwIO (Sha256SumError "sha256 mismatch")
-                    Left e -> throwIO (ConnectionError e)
-      Right _ -> throwIO (ConnectionError "error sending transit message")
+                      -- 3. send encrypted chunks of N bytes to the peer
+                      (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
+                      -- 4. read a record that should contain the transit Ack.
+                      --    If ack is not ok or the sha256sum is incorrect, flag an error.
+                      rxAckMsg <- receiveAckMessage endpoint rRecordKey
+                      closeConnection endpoint
+                      case rxAckMsg of
+                        Right rxSha256Hash ->
+                          if (txSha256Hash /= rxSha256Hash)
+                          then return $ Left (Sha256SumError "sha256 mismatch")
+                          else return (Right ())
+                        Left e -> return $ Left (ConnectionError e)
+      Right _ -> return $ Left (ConnectionError "error sending transit message")
 
 
-receiveFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> TransitMsg -> IO ()
+receiveFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> TransitMsg -> IO (Either CommunicationError ())
 receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
   let abilities' = [Ability DirectTcpV1, Ability RelayV1]
   s <- tcpListener
@@ -137,27 +141,30 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
         let allHints = Set.toList (peerHints <> ourRelayHints)
         withAsync (startClient allHints) $ \asyncClient -> do
           ep <- waitAny [asyncServer, asyncClient]
-          let endpoint = snd ep
-          -- 0. derive transit key
-          let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
-          -- 1. handshakeExchange
-          receiverHandshakeExchange endpoint transitKey side
-          -- 2. create sender/receiver record key, sender record key
-          --    for decrypting incoming records, receiver record key
-          --    for sending the file_ack back at the end.
-          let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
-                                <*> makeReceiverRecordKey transitKey
-          case maybeRecordKeys of
-            Nothing -> throwIO (TransitError "could not create record keys")
-            Just (sRecordKey, rRecordKey) -> do
-              -- 3. receive and decrypt records (length followed by length
-              --    sized packets). Also keep track of decrypted size in
-              --    order to know when to send the file ack at the end.
-              (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
-              TIO.putStrLn (show rxSha256Sum)
-              sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
-              -- close the connection
-              closeConnection endpoint
-      Right _ -> throwIO (UnknownPeerMessage "Could not decode message")
-receiveFile _ _ _ _ = throwIO (UnknownPeerMessage "Could not recognize the message")
+          let endpoint' = snd ep
+          case endpoint' of
+            Left e -> return (Left e)
+            Right endpoint -> do
+              -- 0. derive transit key
+              let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
+              -- 1. handshakeExchange
+              receiverHandshakeExchange endpoint transitKey side
+              -- 2. create sender/receiver record key, sender record key
+              --    for decrypting incoming records, receiver record key
+              --    for sending the file_ack back at the end.
+              let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
+                                    <*> makeReceiverRecordKey transitKey
+              case maybeRecordKeys of
+                Nothing -> return $ Left (TransitError "could not create record keys")
+                Just (sRecordKey, rRecordKey) -> do
+                  -- 3. receive and decrypt records (length followed by length
+                  --    sized packets). Also keep track of decrypted size in
+                  --    order to know when to send the file ack at the end.
+                  (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
+                  TIO.putStrLn (show rxSha256Sum)
+                  sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
+                  -- close the connection
+                  Right <$> closeConnection endpoint
+      Right _ -> return $ Left (UnknownPeerMessage "Could not decode message")
+receiveFile _ _ _ _ = return $ Left (UnknownPeerMessage "Could not recognize the message")
 

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -114,7 +114,7 @@ sendFile conn transitserver appid filepath = do
                           if (txSha256Hash /= rxSha256Hash)
                           then return $ Left (Sha256SumError "sha256 mismatch")
                           else return (Right ())
-                        Left e -> return $ Left (ConnectionError e)
+                        Left e -> return $ Left e
       Right _ -> return $ Left (ConnectionError "error sending transit message")
 
 

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -9,15 +9,19 @@ where
 
 import Protolude
 
+import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Data.Aeson as Aeson
 import qualified Data.Text.IO as TIO
 import qualified Conduit as C
 import qualified Data.Set as Set
+import qualified Data.ByteString.Lazy as BL
 
 import Network.Socket (socketPort)
 
 import qualified MagicWormhole
 
+import Transit.Internal.Errors (Error(..))
+import Transit.Internal.Crypto (CipherText(..))
 import Transit.Internal.Network
   ( tcpListener
   , buildHints
@@ -25,9 +29,9 @@ import Transit.Internal.Network
   , startServer
   , startClient
   , closeConnection
-  , RelayEndpoint)
-
-import Transit.Internal.Errors(CommunicationError(..))
+  , RelayEndpoint
+  , CommunicationError(..)
+  , TCPEndpoint)
 
 import Transit.Internal.Peer
   ( makeSenderRecordKey
@@ -35,19 +39,21 @@ import Transit.Internal.Peer
   , senderHandshakeExchange
   , senderTransitExchange
   , senderFileOfferExchange
-  , receiveAckMessage
   , receiveWormholeMessage
   , sendTransitMsg
   , sendWormholeMessage
   , receiverHandshakeExchange
-  , sendGoodAckMessage
-  , generateTransitSide)
+  , makeGoodAckMessage
+  , generateTransitSide
+  , sendRecord
+  , receiveRecord)
 
 import Transit.Internal.Messages
   ( TransitMsg( Transit, Answer )
   , Ability(..)
   , AbilityV1(..)
-  , Ack( FileAck ))
+  , Ack( FileAck )
+  , TransitAck (..))
 
 import Transit.Internal.Pipeline
   ( sendPipeline
@@ -61,13 +67,33 @@ data MessageType
 transitPurpose :: MagicWormhole.AppID -> ByteString
 transitPurpose (MagicWormhole.AppID appID) = toS appID <> "/transit-key"
 
+sendGoodAckMessage :: TCPEndpoint -> SecretBox.Key -> ByteString -> IO (Either Error ())
+sendGoodAckMessage ep key sha256Sum = do
+  let goodAckMessage = makeGoodAckMessage key sha256Sum
+  case goodAckMessage of
+    Right (CipherText encMsg) -> do
+      res <- sendRecord ep encMsg
+      return $ bimap GeneralError (const ()) res
+    Left e -> return $ Left (CipherError e)
+
+receiveAckMessage :: TCPEndpoint -> SecretBox.Key -> IO (Either Error Text)
+receiveAckMessage ep key = do
+  ackBytes <- (fmap . fmap) BL.fromStrict (receiveRecord ep key)
+  case ackBytes of
+    Left e -> return $ Left (CipherError e)
+    Right ack' ->
+      case Aeson.eitherDecode ack' of
+        Right (TransitAck msg checksum) | msg == "ok" -> return (Right checksum)
+                                        | otherwise -> return $ Left (GeneralError (TransitError "transit ack failure"))
+        Left s -> return $ Left (GeneralError (TransitError (toS ("transit ack failure: " <> s))))
+
 -- | Given the magic-wormhole session, appid, password, a function to print a helpful message
 -- on the command the receiver needs to type (simplest would be just a `putStrLn`) and the
 -- path on the disk of the sender of the file that needs to be sent, `sendFile` sends it via
 -- the wormhole securely. The receiver, on successfully receiving the file, would compute
 -- a sha256 sum of the encrypted file and sends it across to the sender, along with an
 -- acknowledgement, which the sender can verify.
-sendFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> FilePath -> IO (Either CommunicationError ())
+sendFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> FilePath -> IO (Either Error ())
 sendFile conn transitserver appid filepath = do
   -- exchange abilities
   sock' <- tcpListener
@@ -78,12 +104,12 @@ sendFile conn transitserver appid filepath = do
     let ourRelayHints = buildRelayHints transitserver
     transitResp <- senderTransitExchange conn (Set.toList ourHints)
     case transitResp of
-      Left s -> return $ Left (TransitError s)
+      Left s -> return $ Left (GeneralError s)
       Right (Transit peerAbilities peerHints) -> do
         -- send offer for the file
         offerResp <- senderFileOfferExchange conn filepath
         case offerResp of
-          Left s -> return (Left (OfferError s))
+          Left s -> return (Left (GeneralError (OfferError s)))
           Right _ -> do
             -- combine our relay hints with peer's direct and relay hints
             let allHints = Set.toList $ ourRelayHints <> peerHints
@@ -91,7 +117,7 @@ sendFile conn transitserver appid filepath = do
               ep <- waitAny [asyncServer, asyncClient]
               let endpoint' = snd ep
               case endpoint' of
-                Left e -> return (Left e)
+                Left e -> return (Left (GeneralError e))
                 Right endpoint -> do
                   -- 0. derive transit key
                   let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
@@ -99,7 +125,7 @@ sendFile conn transitserver appid filepath = do
                       maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
                                         <*> makeReceiverRecordKey transitKey
                   case maybeRecordKeys of
-                    Nothing -> return (Left (TransitError "could not create record keys"))
+                    Nothing -> return (Left (GeneralError (TransitError "could not create record keys")))
                     Just (sRecordKey, rRecordKey) -> do
                       -- 2. handshakeExchange
                       senderHandshakeExchange endpoint transitKey side
@@ -113,13 +139,13 @@ sendFile conn transitserver appid filepath = do
                       case rxAckMsg of
                         Right rxSha256Hash ->
                           if (txSha256Hash /= rxSha256Hash)
-                          then return $ Left (Sha256SumError "sha256 mismatch")
+                          then return $ Left (GeneralError (Sha256SumError "sha256 mismatch"))
                           else return (Right ())
                         Left e -> return $ Left e
-      Right _ -> return $ Left (ConnectionError "error sending transit message")
+      Right _ -> return $ Left (GeneralError (ConnectionError "error sending transit message"))
 
 
-receiveFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> TransitMsg -> IO (Either CommunicationError ())
+receiveFile :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> TransitMsg -> IO (Either Error ())
 receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
   let abilities' = [Ability DirectTcpV1, Ability RelayV1]
   s <- tcpListener
@@ -132,7 +158,7 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
     -- now expect an offer message
     offerMsg <- receiveWormholeMessage conn
     case Aeson.eitherDecode (toS offerMsg) of
-      Left err -> return $ Left (OfferError $ "unable to decode offer msg: " <> toS err)
+      Left err -> return $ Left (GeneralError (OfferError $ "unable to decode offer msg: " <> toS err))
       Right (MagicWormhole.File name size) -> do
         -- TODO: if the file already exist in the current dir, abort
         -- send an answer message with file_ack.
@@ -144,7 +170,7 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
           ep <- waitAny [asyncServer, asyncClient]
           let endpoint' = snd ep
           case endpoint' of
-            Left e -> return (Left e)
+            Left e -> return (Left (GeneralError e))
             Right endpoint -> do
               -- 0. derive transit key
               let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
@@ -156,7 +182,7 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
               let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
                                     <*> makeReceiverRecordKey transitKey
               case maybeRecordKeys of
-                Nothing -> return $ Left (TransitError "could not create record keys")
+                Nothing -> return $ Left (GeneralError (TransitError "could not create record keys"))
                 Just (sRecordKey, rRecordKey) -> do
                   -- 3. receive and decrypt records (length followed by length
                   --    sized packets). Also keep track of decrypted size in
@@ -166,6 +192,6 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
                   _ <- sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
                   -- close the connection
                   Right <$> closeConnection endpoint
-      Right _ -> return $ Left (UnknownPeerMessage "Could not decode message")
-receiveFile _ _ _ _ = return $ Left (UnknownPeerMessage "Could not recognize the message")
+      Right _ -> return $ Left (GeneralError (UnknownPeerMessage "Could not decode message"))
+receiveFile _ _ _ _ = return $ Left (GeneralError (UnknownPeerMessage "Could not recognize the message"))
 

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -163,7 +163,7 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
                   --    order to know when to send the file ack at the end.
                   (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
                   TIO.putStrLn (show rxSha256Sum)
-                  sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
+                  _ <- sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
                   -- close the connection
                   Right <$> closeConnection endpoint
       Right _ -> return $ Left (UnknownPeerMessage "Could not decode message")

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -131,7 +131,7 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
     -- now expect an offer message
     offerMsg <- receiveWormholeMessage conn
     case Aeson.eitherDecode (toS offerMsg) of
-      Left err -> throwIO (OfferError $ "unable to decode offer msg: " <> toS err)
+      Left err -> return $ Left (OfferError $ "unable to decode offer msg: " <> toS err)
       Right (MagicWormhole.File name size) -> do
         -- TODO: if the file already exist in the current dir, abort
         -- send an answer message with file_ack.

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -128,20 +128,22 @@ sendFile conn transitserver appid filepath = do
                     Nothing -> return (Left (GeneralError (TransitError "could not create record keys")))
                     Just (sRecordKey, rRecordKey) -> do
                       -- 2. handshakeExchange
-                      senderHandshakeExchange endpoint transitKey side
-
-                      -- 3. send encrypted chunks of N bytes to the peer
-                      (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
-                      -- 4. read a record that should contain the transit Ack.
-                      --    If ack is not ok or the sha256sum is incorrect, flag an error.
-                      rxAckMsg <- receiveAckMessage endpoint rRecordKey
-                      closeConnection endpoint
-                      case rxAckMsg of
-                        Right rxSha256Hash ->
-                          if (txSha256Hash /= rxSha256Hash)
-                          then return $ Left (GeneralError (Sha256SumError "sha256 mismatch"))
-                          else return (Right ())
-                        Left e -> return $ Left e
+                      handshake <- senderHandshakeExchange endpoint transitKey side
+                      case handshake of
+                        Left e -> return (Left (HandshakeError e))
+                        Right _ -> do
+                          -- 3. send encrypted chunks of N bytes to the peer
+                          (txSha256Hash, _) <- C.runConduitRes (sendPipeline filepath endpoint sRecordKey)
+                          -- 4. read a record that should contain the transit Ack.
+                          --    If ack is not ok or the sha256sum is incorrect, flag an error.
+                          rxAckMsg <- receiveAckMessage endpoint rRecordKey
+                          closeConnection endpoint
+                          case rxAckMsg of
+                            Right rxSha256Hash ->
+                              if (txSha256Hash /= rxSha256Hash)
+                              then return $ Left (GeneralError (Sha256SumError "sha256 mismatch"))
+                              else return (Right ())
+                            Left e -> return $ Left e
       Right _ -> return $ Left (GeneralError (ConnectionError "error sending transit message"))
 
 
@@ -175,23 +177,26 @@ receiveFile conn transitserver appid (Transit peerAbilities peerHints) = do
               -- 0. derive transit key
               let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
               -- 1. handshakeExchange
-              receiverHandshakeExchange endpoint transitKey side
-              -- 2. create sender/receiver record key, sender record key
-              --    for decrypting incoming records, receiver record key
-              --    for sending the file_ack back at the end.
-              let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
-                                    <*> makeReceiverRecordKey transitKey
-              case maybeRecordKeys of
-                Nothing -> return $ Left (GeneralError (TransitError "could not create record keys"))
-                Just (sRecordKey, rRecordKey) -> do
-                  -- 3. receive and decrypt records (length followed by length
-                  --    sized packets). Also keep track of decrypted size in
-                  --    order to know when to send the file ack at the end.
-                  (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
-                  TIO.putStrLn (show rxSha256Sum)
-                  _ <- sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
-                  -- close the connection
-                  Right <$> closeConnection endpoint
+              handshake <- receiverHandshakeExchange endpoint transitKey side
+              case handshake of
+                Left e -> return (Left (HandshakeError e))
+                Right _ -> do
+                  -- 2. create sender/receiver record key, sender record key
+                  --    for decrypting incoming records, receiver record key
+                  --    for sending the file_ack back at the end.
+                  let maybeRecordKeys = (,) <$> makeSenderRecordKey transitKey
+                                        <*> makeReceiverRecordKey transitKey
+                  case maybeRecordKeys of
+                    Nothing -> return $ Left (GeneralError (TransitError "could not create record keys"))
+                    Just (sRecordKey, rRecordKey) -> do
+                      -- 3. receive and decrypt records (length followed by length
+                      --    sized packets). Also keep track of decrypted size in
+                      --    order to know when to send the file ack at the end.
+                      (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) endpoint sRecordKey
+                      TIO.putStrLn (show rxSha256Sum)
+                      _ <- sendGoodAckMessage endpoint rRecordKey (toS rxSha256Sum)
+                      -- close the connection
+                      Right <$> closeConnection endpoint
       Right _ -> return $ Left (GeneralError (UnknownPeerMessage "Could not decode message"))
 receiveFile _ _ _ _ = return $ Left (GeneralError (UnknownPeerMessage "Could not recognize the message"))
 

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -19,13 +19,12 @@ module Transit.Internal.Network
   , tcpListener
   , startServer
   , startClient
-    -- * Error
-  , CommunicationError(..)
   ) where
 
 import Prelude (read)
 import Protolude
 
+import Transit.Internal.Errors (CommunicationError(..))
 import Transit.Internal.Messages (ConnectionHint(..), Hint(..), AbilityV1(..))
 
 import Network.Socket
@@ -174,21 +173,6 @@ startServer sock' = do
   res <- try $ accept sock' :: IO (Either IOError (Socket, SockAddr))
   close sock'
   return $ bimap (const (ConnectionError "accept: IO error")) (\(conn, _) -> (TCPEndpoint conn Nothing)) res
-
-data CommunicationError
-  = ConnectionError Text
-  -- ^ We could not establish a socket connection.
-  | OfferError Text
-  -- ^ Clients could not exchange offer message.
-  | TransitError Text
-  -- ^ There was an error in transit protocol exchanges.
-  | Sha256SumError Text
-  -- ^ Sender got back a wrong sha256sum from the receiver.
-  | UnknownPeerMessage Text
-  -- ^ We could not identify the message from peer.
-  deriving (Eq, Show)
-
-instance Exception CommunicationError
 
 startClient :: [ConnectionHint] -> IO (Either CommunicationError TCPEndpoint)
 startClient hs = do

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -19,12 +19,13 @@ module Transit.Internal.Network
   , tcpListener
   , startServer
   , startClient
+  -- * Errors
+  , CommunicationError(..)
   ) where
 
 import Prelude (read)
 import Protolude
 
-import Transit.Internal.Errors (CommunicationError(..))
 import Transit.Internal.Messages (ConnectionHint(..), Hint(..), AbilityV1(..))
 
 import Network.Socket
@@ -66,6 +67,19 @@ import System.IO.Error (IOError)
 
 import qualified Data.Text.IO as TIO
 import qualified Data.Set as Set
+
+data CommunicationError
+  = ConnectionError Text
+  -- ^ We could not establish a socket connection.
+  | OfferError Text
+  -- ^ Clients could not exchange offer message.
+  | TransitError Text
+  -- ^ There was an error in transit protocol exchanges.
+  | Sha256SumError Text
+  -- ^ Sender got back a wrong sha256sum from the receiver.
+  | UnknownPeerMessage Text
+  -- ^ We could not identify the message from peer.
+  deriving (Eq, Show)
 
 tcpListener :: IO Socket
 tcpListener = do

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -40,6 +40,7 @@ import Network.Socket
   , close
   , socket
   , Socket(..)
+  , SockAddr
   , connect
   , bind
   , listen
@@ -62,6 +63,7 @@ import Network.Socket.ByteString (send, recv)
 import System.Timeout (timeout)
 import Data.Text (splitOn)
 import Data.String (String)
+import System.IO.Error (IOError)
 
 import qualified Data.Text.IO as TIO
 import qualified Data.Set as Set
@@ -167,11 +169,11 @@ recvBuffer ep = recv (sock ep)
 closeConnection :: TCPEndpoint -> IO ()
 closeConnection ep = close (sock ep)
 
-startServer :: Socket -> IO TCPEndpoint
+startServer :: Socket -> IO (Either CommunicationError TCPEndpoint)
 startServer sock' = do
-  (conn, _) <- accept sock'
+  res <- try $ accept sock' :: IO (Either IOError (Socket, SockAddr))
   close sock'
-  return (TCPEndpoint conn Nothing)
+  return $ bimap (const (ConnectionError "accept: IO error")) (\(conn, _) -> (TCPEndpoint conn Nothing)) res
 
 data CommunicationError
   = ConnectionError Text
@@ -188,7 +190,7 @@ data CommunicationError
 
 instance Exception CommunicationError
 
-startClient :: [ConnectionHint] -> IO TCPEndpoint
+startClient :: [ConnectionHint] -> IO (Either CommunicationError TCPEndpoint)
 startClient hs = do
   let sortedHs = sort hs
       (dHs, rHs) = segregateHints sortedHs
@@ -199,8 +201,8 @@ startClient hs = do
                 (asum (map (tryToConnect RelayV1) rHs))
   let maybeEndPoint = ep1 <|> ep2
   case maybeEndPoint of
-    Just ep -> return ep
-    Nothing -> throwIO (ConnectionError "Peer socket is not active")
+    Just ep -> return (Right ep)
+    Nothing -> return (Left (ConnectionError "Peer socket is not active"))
   where
     -- (a -> b -> b) -> b -> [a] -> b
     segregateHints :: [ConnectionHint] -> ([Hint], [Hint])

--- a/src/Transit/Internal/Network.hs
+++ b/src/Transit/Internal/Network.hs
@@ -19,7 +19,7 @@ module Transit.Internal.Network
   , tcpListener
   , startServer
   , startClient
-  -- * Errors
+    -- * Errors
   , CommunicationError(..)
   ) where
 

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -15,7 +15,7 @@ module Transit.Internal.Peer
   , receiverHandshakeExchange
   , sendTransitMsg
   , decodeTransitMsg
-  , makeGoodAckMessage
+  , makeAckMessage
   , receiveWormholeMessage
   , sendWormholeMessage
   , generateTransitSide
@@ -251,8 +251,8 @@ receiverHandshakeExchange ep key side = do
         rHandshakeMsg = makeReceiverHandshake key
         recvByteString n = recvBuffer ep n
     
-makeGoodAckMessage :: SecretBox.Key -> ByteString -> Either CryptoError CipherText
-makeGoodAckMessage key sha256Sum =
+makeAckMessage :: SecretBox.Key -> ByteString -> Either CryptoError CipherText
+makeAckMessage key sha256Sum =
   let transitAckMsg = TransitAck "ok" (toS @ByteString @Text sha256Sum)
   in
     encrypt key Saltine.zero (PlainText (BL.toStrict (encode transitAckMsg)))

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -145,14 +145,14 @@ receiveOffer conn = do
     Right dir@(MagicWormhole.Directory _ _ _ _ _) -> return $ Right dir
     Left _ -> return $ Left received
 
-receiveMessageAck :: MagicWormhole.EncryptedConnection -> IO ()
+receiveMessageAck :: MagicWormhole.EncryptedConnection -> IO (Either CommunicationError ())
 receiveMessageAck conn = do
   rxTransitMsg <- receiveWormholeMessage conn
   case eitherDecode (toS rxTransitMsg) of
-    Left s -> throwIO (TransitError (show s))
-    Right (Answer (MessageAck msg')) | msg' == "ok" -> return ()
-                                     | otherwise -> throwIO (TransitError "Message ack failed")
-    Right s -> throwIO (TransitError (show s))
+    Left s -> return $ Left (TransitError (show s))
+    Right (Answer (MessageAck msg')) | msg' == "ok" -> return $ Right ()
+                                     | otherwise -> return $ Left (TransitError "Message ack failed")
+    Right s -> return $ Left (TransitError (show s))
 
 sendMessageAck :: MagicWormhole.EncryptedConnection -> Text -> IO ()
 sendMessageAck conn msg = do

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -244,13 +244,13 @@ receiverHandshakeExchange ep key side = do
         rHandshakeMsg = makeReceiverHandshake key
         recvByteString n = recvBuffer ep n
     
-receiveAckMessage :: TCPEndpoint -> SecretBox.Key -> IO (Either Text Text)
+receiveAckMessage :: TCPEndpoint -> SecretBox.Key -> IO (Either CommunicationError Text)
 receiveAckMessage ep key = do
   ackBytes <- BL.fromStrict <$> receiveRecord ep key
   case eitherDecode ackBytes of
     Right (TransitAck msg checksum) | msg == "ok" -> return (Right checksum)
-                                    | otherwise -> return (Left "transit ack failure")
-    Left s -> return (Left $ toS ("transit ack failure: " <> s))
+                                    | otherwise -> return $ Left (TransitError "transit ack failure")
+    Left s -> return $ Left (TransitError (toS ("transit ack failure: " <> s)))
 
 sendGoodAckMessage :: TCPEndpoint -> SecretBox.Key -> ByteString -> IO ()
 sendGoodAckMessage ep key sha256Sum = do

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -26,7 +26,8 @@ import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Crypto.Saltine.Class as Saltine
 
 import Transit.Internal.Network (TCPEndpoint(..))
-import Transit.Internal.Crypto (encrypt, decrypt, PlainText(..), CipherText(..), CryptoError(..))
+import Transit.Internal.Crypto (encrypt, decrypt, PlainText(..), CipherText(..))
+import Transit.Internal.Errors(CommunicationError(..))
 
 -- | Given the peer network socket and the file path to be sent, this Conduit
 -- pipeline reads the file, encrypts and send it over the network. A sha256

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -26,8 +26,7 @@ import qualified Crypto.Saltine.Core.SecretBox as SecretBox
 import qualified Crypto.Saltine.Class as Saltine
 
 import Transit.Internal.Network (TCPEndpoint(..))
-import Transit.Internal.Crypto (encrypt, decrypt, PlainText(..), CipherText(..))
-import Transit.Internal.Errors(CommunicationError(..))
+import Transit.Internal.Crypto (encrypt, decrypt, PlainText(..), CipherText(..), CryptoError(..))
 
 -- | Given the peer network socket and the file path to be sent, this Conduit
 -- pipeline reads the file, encrypts and send it over the network. A sha256

--- a/todo.org
+++ b/todo.org
@@ -8,16 +8,16 @@
    The ack message is of this form: {"ack": "ok", "sha256": "e4f1684a5375ebf7f1dcde02a66026f937a8c6195adf31813ef21b3ccadfb11f"}
 
 ** Tests (hedgehog round trip tests for json messages) (DONE)
-** support for transit protocol for files.
+** support for transit protocol for files. (DONE)
 *** direct tcp connection
 **** Send (DONE)
-**** Receive
+**** Receive (DONE)
 *** via relay
-**** Send
-**** Receive
-** Setup CI system
+**** Send (DONE)
+**** Receive (DONE)
+** Setup CI system (DONE)
 ** Integration tests with python app.
 ** Try to optimize the wordlist completion in receive (256*2 entry table instead of 256*256 entries)
 ** support for directory transfers via transit protocol.
-** error handling at the moment is terrible. This needs to be thought through and fixed.
-** review the exposed functions from wormhole library and see if they strictly need to be exposed.
+** error handling at the moment is terrible. This needs to be thought through and fixed.(ONGOING)
+** review the exposed functions from wormhole library and see if they strictly need to be exposed.(ONGOING)


### PR DESCRIPTION
Closes #5.

- Get rid of throwIO calls in functions.
- Define module-wise Error types and a global Error type.
- return `IO (Either Error a)` rather than `IO a` from as many functions in the IO monad as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/43)
<!-- Reviewable:end -->
