### PR TITLE
Fix version ranges for the build dependencies of the library

### DIFF
--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -29,26 +29,26 @@ library
                      , Transit.Internal.Messages
                      , Transit.Internal.Pipeline
                      , Transit.Internal.Crypto
-  build-depends:       base >=4.6 && <5
-                     , bytestring
-                     , async
-                     , aeson >=1.4 && <2
-                     , binary
-                     , conduit
-                     , conduit-extra
-                     , containers
-                     , magic-wormhole
-                     , memory
-                     , network >=2.7 && <3
-                     , protolude
-                     , hex
-                     , saltine
-                     , cryptonite
-                     , spake2 >= 0.4
-                     , text
-                     , unix-compat
-                     , network-info
-                     , filepath
+  build-depends:       base            >= 4.6     && < 5
+                     , bytestring      >= 0.9     && < 0.11
+                     , async           >= 2.1.0
+                     , aeson           >= 1.4     && < 2
+                     , binary          >= 0.7     && < 0.10
+                     , conduit         >= 1.2.13
+                     , conduit-extra   >  1.0.0
+                     , containers      >= 0.5.10.2
+                     , magic-wormhole  >= 0.1.0
+                     , memory          >= 0.14.15
+                     , network         >= 2.7     && < 3
+                     , protolude       >= 0.2.1
+                     , hex             >= 0.1.2
+                     , saltine         == 0.1.0.1
+                     , cryptonite      >= 0.24
+                     , spake2          >= 0.4
+                     , text            >= 1.2.1.0 && < 1.3
+                     , unix-compat     >= 0.5.0.1
+                     , network-info    >= 0.2.0.9
+                     , filepath        >= 1.4.0.0
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications
   ghc-options: -Wall -Werror=incomplete-patterns


### PR DESCRIPTION
It is a good idea to specify the exact range of our build dependencies and maintain the upper bounds. I found [this reddit discussion](https://www.reddit.com/r/haskell/comments/3aluum/how_to_restrict_package_version_in_cabal_file/) pretty informative. Another option would be to use `cabal freeze` and check-in the resultant `cabal.config` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/45)
<!-- Reviewable:end -->
