### PR TITLE
Refactor the application

### DIFF
--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -21,13 +21,14 @@ import Protolude
 
 import qualified Data.Text.IO as TIO
 import qualified Transit
+import Control.Monad.Trans.Except (runExceptT)
 
 import Options
 
 main :: IO ()
 main = do
   env <- Transit.prepareAppEnv appid "wordlist.txt" =<< commandlineParser
-  result <- Transit.app env
+  result <- runExceptT (runReaderT Transit.app env)
   either (TIO.putStrLn . show) return result
     where
       appid = "lothar.com/wormhole/text-or-file-xfer"

--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -21,14 +21,13 @@ import Protolude
 
 import qualified Data.Text.IO as TIO
 import qualified Transit
-import Control.Monad.Trans.Except (runExceptT)
 
 import Options
 
 main :: IO ()
 main = do
   env <- Transit.prepareAppEnv appid "wordlist.txt" =<< commandlineParser
-  result <- runExceptT (runReaderT Transit.app env)
+  result <- Transit.runApp Transit.app env
   either (TIO.putStrLn . show) return result
     where
       appid = "lothar.com/wormhole/text-or-file-xfer"

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -32,36 +32,30 @@ library
                      , Transit.Internal.Messages
                      , Transit.Internal.Pipeline
                      , Transit.Internal.Crypto
-  build-depends:       base            >= 4.6     && < 5
-                     , bytestring      >= 0.9     && < 1.0
+  build-depends:       aeson           >= 1.4     && < 2
                      , async           >= 2.1.0   && < 3.0
-                     , aeson           >= 1.4     && < 2
+                     , base            >= 4.6     && < 5
                      , binary          >= 0.7     && < 1.0
+                     , bytestring      >= 0.9     && < 1.0
                      , conduit         >= 1.2.13  && < 2.0
                      , conduit-extra   >  1.0.0   && < 2.0
                      , containers      >= 0.5.10  && < 1.0
+                     , cryptonite      >= 0.24    && < 1.0
+                     , filepath        >= 1.4.0   && < 2.0
+                     , haskeline       >= 0.7.4   && < 1.0
+                     , hex             >= 0.1.2   && < 1.0
                      , magic-wormhole  >= 0.1.0   && < 1.0
                      , memory          >= 0.14.15 && < 1.0
+                     , mtl             >= 2.2.2   && < 3.0
                      , network         >= 2.7     && < 3
+                     , network-info    >= 0.2.0   && < 1.0
                      , protolude       >= 0.2.1   && < 1.0
-                     , haskeline
-                     , hex
-                     , magic-wormhole
-                     , memory
-                     , mtl
-                     , network >=2.7 && <3
-                     , network-info
-                     , protolude
-                     , random
-                     , hex             >= 0.1.2   && < 1.0
+                     , random          >= 1.1     && < 2.0
                      , saltine         == 0.1.0.1 && < 1.0
-                     , cryptonite      >= 0.24    && < 1.0
                      , spake2          >= 0.4     && < 1.0
                      , text            >= 1.2.1   && < 2.0
+                     , transformers    >= 0.5.5   && < 1.0
                      , unix-compat     >= 0.5.0   && < 1.0
-                     , network-info    >= 0.2.0   && < 1.0
-                     , filepath        >= 1.4.0   && < 2.0
-                     , transformers
   other-modules:       Paths_hwormhole
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -54,6 +54,7 @@ library
                      , unix-compat     >= 0.5.0   && < 1.0
                      , network-info    >= 0.2.0   && < 1.0
                      , filepath        >= 1.4.0   && < 2.0
+                     , transformers
   other-modules:       Paths_hwormhole
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications
@@ -71,6 +72,7 @@ executable hwormhole-exe
                      , optparse-applicative
                      , protolude
                      , text
+                     , transformers
   hs-source-dirs:      cmd
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -45,6 +45,13 @@ library
                      , network         >= 2.7     && < 3
                      , protolude       >= 0.2.1   && < 1.0
                      , haskeline
+                     , hex
+                     , magic-wormhole
+                     , memory
+                     , mtl
+                     , network >=2.7 && <3
+                     , network-info
+                     , protolude
                      , random
                      , hex             >= 0.1.2   && < 1.0
                      , saltine         == 0.1.0.1 && < 1.0

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -22,6 +22,7 @@ module Transit
   ( App.Env(..)
   , App.prepareAppEnv
   , App.app
+  , App.runApp
   , Conf.Options(..)
   , Conf.Command(..)
   , Errors.Error(..)


### PR DESCRIPTION
Refactor functions to use a Configuration and return IO (Either Error a). We do that in steps in the below commits.

1. We refactor command line processing a bit.
2. move configuration types into a separate module and make a Reader that takes a read-only environment.
3. Use `ReaderT Config (IO (Either Error a))`
4. Convert into `ReaderT Config (EitherT Error IO a)`
5. newtype called `App a`for the above type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/47)
<!-- Reviewable:end -->
