### PR TITLE
Preparation for introducing an App monad

### DIFF
--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -25,7 +25,6 @@ import qualified Data.Text.IO as TIO
 import qualified System.Console.Haskeline as H
 import qualified System.Console.Haskeline.Completion as HC
 import System.Random (randomR, getStdGen)
-import qualified Options.Applicative as Opt
 import qualified Crypto.Spake2 as Spake2
 
 import Data.String (String)
@@ -178,7 +177,7 @@ receive session transitserver appid code = do
 
 main :: IO ()
 main = do
-  options <- Opt.execParser opts
+  options <- commandlineParser
   wordList <- genWordList =<< getDataFileName "wordlist.txt"
   side <- MagicWormhole.generateSide
   let endpoint = relayEndpoint options

--- a/cmd/Main.hs
+++ b/cmd/Main.hs
@@ -14,170 +14,20 @@
 -- along with hwormhole.  If not, see <http://www.gnu.org/licenses/>.
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Main where
 
 import Protolude
 
-import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
-import qualified System.Console.Haskeline as H
-import qualified System.Console.Haskeline.Completion as HC
-import System.Random (randomR, getStdGen)
-import qualified Crypto.Spake2 as Spake2
-
-import Data.String (String)
-import System.IO.Error (IOError)
-
-import qualified MagicWormhole
 import qualified Transit
 
 import Options
 
-genPasscodes :: [Text] -> [(Text, Text)] -> [Text]
-genPasscodes nameplates wordpairs =
-  let evens = map fst wordpairs
-      odds = map snd wordpairs
-      wordCombos = [ o <> "-" <> e | o <- odds, e <- evens ]
-  in
-    [ n <> "-" <> hiphenWord | n <- nameplates, hiphenWord <- wordCombos ]
-
-allocatePassword :: [(Text, Text)] -> IO Text
-allocatePassword wordlist = do
-  g <- getStdGen
-  let (r1, g') = randomR (0, 255) g
-      (r2, _) = randomR (0, 255) g'
-      Just evenW = fst <$> atMay wordlist r2
-      Just oddW = snd <$> atMay wordlist r1
-  return $ Text.concat [oddW, "-", evenW]
-
-completeWord :: MonadIO m => [Text] -> HC.CompletionFunc m
-completeWord wordlist = HC.completeWord Nothing "" completionFunc
-  where
-    completionFunc :: Monad m => String -> m [HC.Completion]
-    completionFunc word = do
-      let completions = filter (toS word `Text.isPrefixOf`) wordlist
-      return $ map (HC.simpleCompletion . toS) completions
-
--- | Take an input code from the user with code completion.
--- In order for the code completion to work, we need to find
--- the possible open nameplates, the possible words and then
--- do the completion as the user types the code.
--- TODO: This function does too much. Perfect target for refactoring.
-getCode :: MagicWormhole.Session -> [(Text, Text)] -> IO Text
-getCode session wordList = do
-  nameplates <- MagicWormhole.list session
-  let ns = [ n | MagicWormhole.Nameplate n <- nameplates ]
-  putText "Enter the receive wormhole code: "
-  H.runInputT (settings (genPasscodes ns wordList)) getInput
-  where
-    settings :: MonadIO m => [Text] -> H.Settings m
-    settings possibleWords = H.Settings
-      { H.complete = completeWord possibleWords
-      , H.historyFile = Nothing
-      , H.autoAddHistory = False
-      }
-    getInput :: H.InputT IO Text
-    getInput = do
-      minput <- H.getInputLine ""
-      case minput of
-        Nothing -> return ""
-        Just input -> return (toS input)
-
-printSendHelpText :: Text -> IO ()
-printSendHelpText passcode = do
-  TIO.putStrLn $  "Wormhole code is: " <> passcode
-  TIO.putStrLn "On the other computer, please run:"
-  TIO.putStrLn ""
-  TIO.putStrLn $ "wormhole receive " <> passcode
-
-type Password = ByteString
-
--- | Given the magic-wormhole session, appid, password, a function to print a helpful message
--- on the command the receiver needs to type (simplest would be just a `putStrLn`) and the
--- path on the disk of the sender of the file that needs to be sent, `sendFile` sends it via
--- the wormhole securely. The receiver, on successfully receiving the file, would compute
--- a sha256 sum of the encrypted file and sends it across to the sender, along with an
--- acknowledgement, which the sender can verify.
-send :: Transit.Env -> MagicWormhole.Session -> Password -> Transit.MessageType -> IO (Either Transit.Error ())
-send env session password tfd = do
-  -- first establish a wormhole session with the receiver and
-  -- then talk the filetransfer protocol over it as follows.
-  let options = Transit.config env
-  let appid = Transit.appID env
-  let transitserver = transitUrl options
-  nameplate <- MagicWormhole.allocate session
-  mailbox <- MagicWormhole.claim session nameplate
-  peer <- MagicWormhole.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
-  let (MagicWormhole.Nameplate n) = nameplate
-  printSendHelpText $ toS n <> "-" <> toS password
-  MagicWormhole.withEncryptedConnection peer (Spake2.makePassword (toS n <> "-" <> password))
-    (\conn ->
-        case tfd of
-          Transit.TMsg msg -> do
-            let offer = MagicWormhole.Message msg
-            Transit.sendOffer conn offer
-            -- wait for "answer" message with "message_ack" key
-            Transit.liftEitherCommError <$> Transit.receiveMessageAck conn
-          Transit.TFile filepath ->
-            Transit.sendFile conn transitserver appid filepath
-    )
-
--- | receive a text message or file from the wormhole peer.
-receive :: Transit.Env -> MagicWormhole.Session -> Text -> IO (Either Transit.Error ())
-receive env session code = do
-  -- establish the connection
-  let options = Transit.config env
-  let appid = Transit.appID env
-  let transitserver = transitUrl options
-  let codeSplit = Text.split (=='-') code
-  let (Just nameplate) = headMay codeSplit
-  mailbox <- MagicWormhole.claim session (MagicWormhole.Nameplate nameplate)
-  peer <- MagicWormhole.open session mailbox
-  MagicWormhole.withEncryptedConnection peer (Spake2.makePassword (toS (Text.strip code)))
-    (\conn -> do
-        -- unfortunately, the receiver has no idea which message to expect.
-        -- If the sender is only sending a text message, it gets an offer first.
-        -- if the sender is sending a file/directory, then transit comes first
-        -- and then offer comes in. `Transit.receiveOffer' will attempt to interpret
-        -- the bytestring as an offer message. If that fails, it passes the raw bytestring
-        -- as a Left value so that we can try to decode it as a TransitMsg.
-        someOffer <- Transit.receiveOffer conn
-        case someOffer of
-          Right (MagicWormhole.Message message) -> do
-            TIO.putStrLn message
-            result <- try (Transit.sendMessageAck conn "ok") :: IO (Either IOError ())
-            return $ bimap (const (Transit.NetworkError (Transit.ConnectionError "sending the ack message failed"))) identity result
-          Right (MagicWormhole.File _ _) -> do
-            Transit.sendMessageAck conn "not_ok"
-            return $ Left (Transit.NetworkError (Transit.ConnectionError "did not expect a file offer"))
-          Right (MagicWormhole.Directory _ _ _ _ _) ->
-            return $ Left (Transit.NetworkError (Transit.UnknownPeerMessage "directory offer is not supported"))
-          -- ok, we received the Transit Message, send back a transit message
-          Left received ->
-            case (Transit.decodeTransitMsg (toS received)) of
-              Left e -> return $ Left (Transit.NetworkError e)
-              Right transitMsg ->
-                Transit.receiveFile conn transitserver appid transitMsg
-    )
-
 main :: IO ()
 main = do
   env <- Transit.prepareAppEnv appid "wordlist.txt" =<< commandlineParser
-  let options = Transit.config env
-      endpoint = relayEndpoint options
-  case cmd options of
-    Send tfd -> MagicWormhole.runClient endpoint (Transit.appID env) (Transit.side env) $ \session -> do
-      password <- allocatePassword (Transit.wordList env)
-      result <- send env session (toS password) tfd
-      either (TIO.putStrLn . show) return result
-    Receive maybeCode -> MagicWormhole.runClient endpoint (Transit.appID env) (Transit.side env) $ \session -> do
-      code <- getWormholeCode session (Transit.wordList env) maybeCode
-      result <- receive env session code
-      either (TIO.putStrLn . show) return result
+  result <- Transit.app env
+  either (TIO.putStrLn . show) return result
     where
       appid = "lothar.com/wormhole/text-or-file-xfer"
-      getWormholeCode :: MagicWormhole.Session -> [(Text, Text)] -> Maybe Text -> IO Text
-      getWormholeCode session wordList Nothing = getCode session wordList
-      getWormholeCode _ _ (Just code) = return code

--- a/cmd/Options.hs
+++ b/cmd/Options.hs
@@ -18,8 +18,6 @@
 
 module Options
   ( commandlineParser
-  , Options(..)
-  , Command(..)
   )
 where
 
@@ -27,16 +25,14 @@ import Protolude
 
 import qualified Options.Applicative as Opt
 
-import qualified MagicWormhole
+import qualified Transit
 
-import Transit
-
-optionsParser :: Opt.Parser Options
+optionsParser :: Opt.Parser Transit.Options
 optionsParser
-  = Options
+  = Transit.Options
     <$> commandParser
     <*> Opt.option
-    (Opt.maybeReader MagicWormhole.parseWebSocketEndpoint)
+    (Opt.maybeReader Transit.parseWebSocketEndpoint)
     ( Opt.long "relayserver-url" <>
       Opt.help "Endpoint for the Relay server" <>
       Opt.value defaultEndpoint <>
@@ -51,30 +47,30 @@ optionsParser
     -- | Default URL for relay server.
     --
     -- This is a relay server run by Brian Warner.
-    defaultEndpoint = fromMaybe (panic "Invalid default URL") (MagicWormhole.parseWebSocketEndpoint "ws://relay.magic-wormhole.io:4000/v1")
+    defaultEndpoint = fromMaybe (panic "Invalid default URL") (Transit.parseWebSocketEndpoint "ws://relay.magic-wormhole.io:4000/v1")
     -- | Default Transit Relay Url
     --
     -- This is a Transit relay run by Brian Warner.
     defaultTransitUrl = fromMaybe (panic "Invalid transit relay URL") (Transit.parseTransitRelayUri "tcp:transit.magic-wormhole.io:4001")
 
-commandParser :: Opt.Parser Command
+commandParser :: Opt.Parser Transit.Command
 commandParser = Opt.hsubparser (sendCommand <> receiveCommand)
   where
     sendCommand = Opt.command "send" (Opt.info sendOptions (Opt.progDesc "send a text message, a file or a directory"))
     receiveCommand = Opt.command "receive" (Opt.info receiveOptions (Opt.progDesc "receive a text message"))
-    receiveOptions :: Opt.Parser Command
-    receiveOptions = Receive <$> optional (Opt.strArgument (Opt.metavar "CODE"))
-    sendOptions :: Opt.Parser Command
-    sendOptions = Send <$> parseMessageType
-    parseMessageType :: Opt.Parser MessageType
+    receiveOptions :: Opt.Parser Transit.Command
+    receiveOptions = Transit.Receive <$> optional (Opt.strArgument (Opt.metavar "CODE"))
+    sendOptions :: Opt.Parser Transit.Command
+    sendOptions = Transit.Send <$> parseMessageType
+    parseMessageType :: Opt.Parser Transit.MessageType
     parseMessageType = msgParser <|> fileOrDirParser
-    msgParser :: Opt.Parser MessageType
-    msgParser = TMsg <$> Opt.strOption (Opt.long "text" <> Opt.help "Text message to send")
-    fileOrDirParser :: Opt.Parser MessageType
-    fileOrDirParser = TFile <$> Opt.strArgument (Opt.metavar "FILENAME" <> Opt.help "file path")
+    msgParser :: Opt.Parser Transit.MessageType
+    msgParser = Transit.TMsg <$> Opt.strOption (Opt.long "text" <> Opt.help "Text message to send")
+    fileOrDirParser :: Opt.Parser Transit.MessageType
+    fileOrDirParser = Transit.TFile <$> Opt.strArgument (Opt.metavar "FILENAME" <> Opt.help "file path")
 
-opts :: Opt.ParserInfo Options
+opts :: Opt.ParserInfo Transit.Options
 opts = Opt.info (Opt.helper <*> optionsParser) (Opt.fullDesc <> Opt.header "wormhole")
 
-commandlineParser :: IO Options
+commandlineParser :: IO Transit.Options
 commandlineParser = Opt.execParser opts

--- a/cmd/Options.hs
+++ b/cmd/Options.hs
@@ -16,7 +16,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Options where
+module Options
+  ( commandlineParser
+  , Options(..)
+  , Command(..)
+  )
+where
 
 import Protolude
 
@@ -82,3 +87,6 @@ commandParser = Opt.hsubparser (sendCommand <> receiveCommand)
 
 opts :: Opt.ParserInfo Options
 opts = Opt.info (Opt.helper <*> optionsParser) (Opt.fullDesc <> Opt.header "wormhole")
+
+commandlineParser :: IO Options
+commandlineParser = Opt.execParser opts

--- a/cmd/Options.hs
+++ b/cmd/Options.hs
@@ -31,18 +31,6 @@ import qualified MagicWormhole
 
 import Transit
 
-data Options
-  = Options
-  { cmd :: Command
-  , relayEndpoint :: MagicWormhole.WebSocketEndpoint
-  , transitUrl :: Transit.RelayEndpoint
-  } deriving (Eq, Show)
-
-data Command
-  = Send MessageType
-  | Receive (Maybe Text)
-  deriving (Eq, Show)
-
 optionsParser :: Opt.Parser Options
 optionsParser
   = Options

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   hs-source-dirs:      src
   exposed-modules:     Transit
+                     , Transit.Internal.Conf
                      , Transit.Internal.Errors
                      , Transit.Internal.FileTransfer
                      , Transit.Internal.Network

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -23,6 +23,7 @@ source-repository head
 library
   hs-source-dirs:      src
   exposed-modules:     Transit
+                     , Transit.Internal.App
                      , Transit.Internal.Conf
                      , Transit.Internal.Errors
                      , Transit.Internal.FileTransfer
@@ -51,14 +52,14 @@ library
                      , unix-compat     >= 0.5.0   && < 1.0
                      , network-info    >= 0.2.0   && < 1.0
                      , filepath        >= 1.4.0   && < 2.0
+  other-modules:       Paths_hwormhole
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications
   ghc-options: -Wall -Werror=incomplete-patterns
 
 executable hwormhole-exe
   main-is:             Main.hs
-  other-modules:       Paths_hwormhole
-                     , Options
+  other-modules:       Options
   -- other-extensions:
   build-depends:       base            >=4.6      && <5
                      , bytestring

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -44,6 +44,8 @@ library
                      , memory          >= 0.14.15 && < 1.0
                      , network         >= 2.7     && < 3
                      , protolude       >= 0.2.1   && < 1.0
+                     , haskeline
+                     , random
                      , hex             >= 0.1.2   && < 1.0
                      , saltine         == 0.1.0.1 && < 1.0
                      , cryptonite      >= 0.24    && < 1.0
@@ -65,13 +67,9 @@ executable hwormhole-exe
                      , bytestring
                      , aeson           >=1.4      && <2
                      , binary
-                     , haskeline
                      , hwormhole
-                     , magic-wormhole
                      , optparse-applicative
                      , protolude
-                     , random
-                     , spake2          >= 0.4
                      , text
   hs-source-dirs:      cmd
   default-language:    Haskell2010

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -34,6 +34,8 @@ module Transit
   , Network.CommunicationError(..)
   , Conf.Options(..)
   , Conf.Command(..)
+  , App.Env(..)
+  , App.prepareAppEnv
   )
 where
 
@@ -42,3 +44,4 @@ import qualified Transit.Internal.Peer as Peer
 import qualified Transit.Internal.Network as Network
 import qualified Transit.Internal.Errors as Errors
 import qualified Transit.Internal.Conf as Conf
+import qualified Transit.Internal.App as App

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -32,6 +32,8 @@ module Transit
   , Network.parseTransitRelayUri
   , Network.RelayEndpoint(..)
   , Network.CommunicationError(..)
+  , Conf.Options(..)
+  , Conf.Command(..)
   )
 where
 
@@ -39,3 +41,4 @@ import qualified Transit.Internal.FileTransfer as FileTransfer
 import qualified Transit.Internal.Peer as Peer
 import qualified Transit.Internal.Network as Network
 import qualified Transit.Internal.Errors as Errors
+import qualified Transit.Internal.Conf as Conf

--- a/src/Transit.hs
+++ b/src/Transit.hs
@@ -19,29 +19,22 @@
 -- so that each message is encrypted using NaCl SecretBox.
 --
 module Transit
-  ( FileTransfer.sendFile
-  , FileTransfer.receiveFile
-  , FileTransfer.MessageType(..)
-  , Peer.sendOffer
-  , Peer.receiveOffer
-  , Peer.receiveMessageAck
-  , Peer.sendMessageAck
-  , Peer.decodeTransitMsg
-  , Errors.Error(..)
-  , Errors.liftEitherCommError
-  , Network.parseTransitRelayUri
-  , Network.RelayEndpoint(..)
-  , Network.CommunicationError(..)
+  ( App.Env(..)
+  , App.prepareAppEnv
+  , App.app
   , Conf.Options(..)
   , Conf.Command(..)
-  , App.Env(..)
-  , App.prepareAppEnv
+  , Errors.Error(..)
+  , Errors.liftEitherCommError
+  , FileTransfer.MessageType(..)
+  , MagicWormhole.parseWebSocketEndpoint
+  , Network.parseTransitRelayUri
   )
 where
 
 import qualified Transit.Internal.FileTransfer as FileTransfer
-import qualified Transit.Internal.Peer as Peer
 import qualified Transit.Internal.Network as Network
 import qualified Transit.Internal.Errors as Errors
 import qualified Transit.Internal.Conf as Conf
 import qualified Transit.Internal.App as App
+import qualified MagicWormhole

--- a/src/Transit/Internal/App.hs
+++ b/src/Transit/Internal/App.hs
@@ -1,0 +1,50 @@
+module Transit.Internal.App
+  ( Env(..)
+  , prepareAppEnv
+  )
+where
+
+import Protolude
+
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TIO
+import qualified MagicWormhole
+
+import Transit.Internal.Conf(Options)
+import Paths_hwormhole
+
+data Env
+  = Env { appID :: MagicWormhole.AppID
+        , side :: MagicWormhole.Side
+        , config :: Options
+        , wordList :: [(Text, Text)]
+        }
+
+-- | genWordlist would produce a list of the form
+--   [ ("aardwark", "adroitness"),
+--     ("absurd", "adviser"),
+--     ....
+--     ("zulu", "yucatan") ]
+genWordList :: FilePath -> IO [(Text, Text)]
+genWordList wordlistFile = do
+  file <- TIO.readFile wordlistFile
+  let contents = map toWordPair $ Text.lines file
+  return contents
+    where
+      toWordPair :: Text -> (Text, Text)
+      toWordPair line =
+        let ws = map Text.toLower $ Text.words line
+            Just firstWord = atMay ws 1
+            Just sndWord = atMay ws 2
+        in (firstWord, sndWord)
+
+prepareAppEnv :: Text -> FilePath -> Options -> IO Env
+prepareAppEnv appid wordlistPath options = do
+  side' <- MagicWormhole.generateSide
+  wordlist <- genWordList =<< getDataFileName wordlistPath
+  let appID' = MagicWormhole.AppID appid
+  return $ Env appID' side' options wordlist
+
+-- newtype AppM a = AppM ( Env -> IO (Either AppError a) )
+-- type AppM a = ReaderT Env (EitherT AppError IO a)
+

--- a/src/Transit/Internal/App.hs
+++ b/src/Transit/Internal/App.hs
@@ -1,6 +1,7 @@
 module Transit.Internal.App
   ( Env(..)
   , prepareAppEnv
+  , app
   )
 where
 
@@ -9,9 +10,21 @@ import Protolude
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
 import qualified MagicWormhole
+import qualified System.Console.Haskeline as H
+import qualified System.Console.Haskeline.Completion as HC
+import qualified Crypto.Spake2 as Spake2
 
-import Transit.Internal.Conf(Options)
+import System.IO.Error (IOError)
+import System.Random (randomR, getStdGen)
+import Data.String (String)
+
+import Transit.Internal.Conf (Options(..), Command(..))
+import Transit.Internal.Errors (Error(..), liftEitherCommError, CommunicationError(..))
+import Transit.Internal.FileTransfer(MessageType(..), sendFile, receiveFile)
+import Transit.Internal.Peer (sendOffer, receiveOffer, receiveMessageAck, sendMessageAck, decodeTransitMsg)
 import Paths_hwormhole
+
+type Password = ByteString
 
 data Env
   = Env { appID :: MagicWormhole.AppID
@@ -45,6 +58,149 @@ prepareAppEnv appid wordlistPath options = do
   let appID' = MagicWormhole.AppID appid
   return $ Env appID' side' options wordlist
 
+allocatePassword :: [(Text, Text)] -> IO Text
+allocatePassword wordlist = do
+  g <- getStdGen
+  let (r1, g') = randomR (0, 255) g
+      (r2, _) = randomR (0, 255) g'
+      Just evenW = fst <$> atMay wordlist r2
+      Just oddW = snd <$> atMay wordlist r1
+  return $ Text.concat [oddW, "-", evenW]
+
+-- | Given the magic-wormhole session, appid, password, a function to print a helpful message
+-- on the command the receiver needs to type (simplest would be just a `putStrLn`) and the
+-- path on the disk of the sender of the file that needs to be sent, `sendFile` sends it via
+-- the wormhole securely. The receiver, on successfully receiving the file, would compute
+-- a sha256 sum of the encrypted file and sends it across to the sender, along with an
+-- acknowledgement, which the sender can verify.
+send :: Env -> MagicWormhole.Session -> Password -> MessageType -> IO (Either Error ())
+send env session password tfd = do
+  -- first establish a wormhole session with the receiver and
+  -- then talk the filetransfer protocol over it as follows.
+  let options = config env
+  let appid = appID env
+  let transitserver = transitUrl options
+  nameplate <- MagicWormhole.allocate session
+  mailbox <- MagicWormhole.claim session nameplate
+  peer <- MagicWormhole.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
+  let (MagicWormhole.Nameplate n) = nameplate
+  printSendHelpText $ toS n <> "-" <> toS password
+  MagicWormhole.withEncryptedConnection peer (Spake2.makePassword (toS n <> "-" <> password))
+    (\conn ->
+        case tfd of
+          TMsg msg -> do
+            let offer = MagicWormhole.Message msg
+            sendOffer conn offer
+            -- wait for "answer" message with "message_ack" key
+            liftEitherCommError <$> receiveMessageAck conn
+          TFile filepath ->
+            sendFile conn transitserver appid filepath
+    )
+
+-- | receive a text message or file from the wormhole peer.
+receive :: Env -> MagicWormhole.Session -> Text -> IO (Either Error ())
+receive env session code = do
+  -- establish the connection
+  let options = config env
+  let appid = appID env
+  let transitserver = transitUrl options
+  let codeSplit = Text.split (=='-') code
+  let (Just nameplate) = headMay codeSplit
+  mailbox <- MagicWormhole.claim session (MagicWormhole.Nameplate nameplate)
+  peer <- MagicWormhole.open session mailbox
+  MagicWormhole.withEncryptedConnection peer (Spake2.makePassword (toS (Text.strip code)))
+    (\conn -> do
+        -- unfortunately, the receiver has no idea which message to expect.
+        -- If the sender is only sending a text message, it gets an offer first.
+        -- if the sender is sending a file/directory, then transit comes first
+        -- and then offer comes in. `Transit.receiveOffer' will attempt to interpret
+        -- the bytestring as an offer message. If that fails, it passes the raw bytestring
+        -- as a Left value so that we can try to decode it as a TransitMsg.
+        someOffer <- receiveOffer conn
+        case someOffer of
+          Right (MagicWormhole.Message message) -> do
+            TIO.putStrLn message
+            result <- try (sendMessageAck conn "ok") :: IO (Either IOError ())
+            return $ bimap (const (NetworkError (ConnectionError "sending the ack message failed"))) identity result
+          Right (MagicWormhole.File _ _) -> do
+            sendMessageAck conn "not_ok"
+            return $ Left (NetworkError (ConnectionError "did not expect a file offer"))
+          Right (MagicWormhole.Directory _ _ _ _ _) ->
+            return $ Left (NetworkError (UnknownPeerMessage "directory offer is not supported"))
+          -- ok, we received the Transit Message, send back a transit message
+          Left received ->
+            case (decodeTransitMsg (toS received)) of
+              Left e -> return $ Left (NetworkError e)
+              Right transitMsg ->
+                receiveFile conn transitserver appid transitMsg
+    )
+
+genPasscodes :: [Text] -> [(Text, Text)] -> [Text]
+genPasscodes nameplates wordpairs =
+  let evens = map fst wordpairs
+      odds = map snd wordpairs
+      wordCombos = [ o <> "-" <> e | o <- odds, e <- evens ]
+  in
+    [ n <> "-" <> hiphenWord | n <- nameplates, hiphenWord <- wordCombos ]
+
+printSendHelpText :: Text -> IO ()
+printSendHelpText passcode = do
+  TIO.putStrLn $  "Wormhole code is: " <> passcode
+  TIO.putStrLn "On the other computer, please run:"
+  TIO.putStrLn ""
+  TIO.putStrLn $ "wormhole receive " <> passcode
+
+completeWord :: MonadIO m => [Text] -> HC.CompletionFunc m
+completeWord wordlist = HC.completeWord Nothing "" completionFunc
+  where
+    completionFunc :: Monad m => String -> m [HC.Completion]
+    completionFunc word = do
+      let completions = filter (toS word `Text.isPrefixOf`) wordlist
+      return $ map (HC.simpleCompletion . toS) completions
+
+-- | Take an input code from the user with code completion.
+-- In order for the code completion to work, we need to find
+-- the possible open nameplates, the possible words and then
+-- do the completion as the user types the code.
+-- TODO: This function does too much. Perfect target for refactoring.
+getCode :: MagicWormhole.Session -> [(Text, Text)] -> IO Text
+getCode session wordlist = do
+  nameplates <- MagicWormhole.list session
+  let ns = [ n | MagicWormhole.Nameplate n <- nameplates ]
+  putText "Enter the receive wormhole code: "
+  H.runInputT (settings (genPasscodes ns wordlist)) getInput
+  where
+    settings :: MonadIO m => [Text] -> H.Settings m
+    settings possibleWords = H.Settings
+      { H.complete = completeWord possibleWords
+      , H.historyFile = Nothing
+      , H.autoAddHistory = False
+      }
+    getInput :: H.InputT IO Text
+    getInput = do
+      minput <- H.getInputLine ""
+      case minput of
+        Nothing -> return ""
+        Just input -> return (toS input)
+
 -- newtype AppM a = AppM ( Env -> IO (Either AppError a) )
 -- type AppM a = ReaderT Env (EitherT AppError IO a)
+
+app :: Env -> IO (Either Error ())
+app env = do
+  let options = config env
+      endpoint = relayEndpoint options
+  case cmd options of
+    Send tfd ->
+      MagicWormhole.runClient endpoint (appID env) (side env) $ \session -> do
+      password <- allocatePassword (wordList env)
+      send env session (toS password) tfd
+    Receive maybeCode ->
+      MagicWormhole.runClient endpoint (appID env) (side env) $ \session -> do
+      code <- getWormholeCode session (wordList env) maybeCode
+      receive env session code
+  where
+    getWormholeCode :: MagicWormhole.Session -> [(Text, Text)] -> Maybe Text -> IO Text
+    getWormholeCode session wordlist Nothing = getCode session wordlist
+    getWormholeCode _ _ (Just code) = return code
 

--- a/src/Transit/Internal/Conf.hs
+++ b/src/Transit/Internal/Conf.hs
@@ -1,0 +1,24 @@
+module Transit.Internal.Conf
+  ( Options(..)
+  , Command(..)
+  )
+where
+
+import Protolude
+
+import qualified MagicWormhole
+
+import Transit.Internal.Network (RelayEndpoint)
+import Transit.Internal.FileTransfer (MessageType)
+
+data Options
+  = Options
+  { cmd :: Command
+  , relayEndpoint :: MagicWormhole.WebSocketEndpoint
+  , transitUrl :: RelayEndpoint
+  } deriving (Eq, Show)
+
+data Command
+  = Send MessageType
+  | Receive (Maybe Text)
+  deriving (Eq, Show)

--- a/src/Transit/Internal/Errors.hs
+++ b/src/Transit/Internal/Errors.hs
@@ -2,6 +2,9 @@ module Transit.Internal.Errors
   ( liftEitherCommError
     -- * Error
   , Error(..)
+  , N.CommunicationError(..)
+  , P.InvalidHandshake
+  , C.CryptoError
   )
 where
 


### PR DESCRIPTION
We are currently passing a lot of environment/configuration data to functions. Most of the top level functions are returning `IO (Either Error a)`. We could possibly stack these monads and create a `ReaderT Env (ExceptT Error IO a)` type to represent these function types. But before that we will need to reorganize the code a bit. That is what these commits are doing. We are moving configuration into its own module. We also creating an `App` module to move the top level `send` and `receive` functions.