### PR TITLE
Directory send/receive support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: "install dependencies"
           command: |
-             apt-get --quiet --yes install git pkg-config libsodium-dev
+             apt-get --quiet --yes install git pkg-config libsodium-dev libbz2-dev
 
       - restore_cache:
           keys:

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -49,6 +49,7 @@ library
                      , mtl             >= 2.2.2   && < 3.0
                      , network         >= 2.7     && < 3
                      , network-info    >= 0.2.0   && < 1.0
+                     , pathwalk        >= 0.3.1.2 && < 1.0
                      , protolude       >= 0.2.1   && < 1.0
                      , random          >= 1.1     && < 2.0
                      , saltine         == 0.1.0.1 && < 1.0
@@ -56,6 +57,7 @@ library
                      , text            >= 1.2.1   && < 2.0
                      , transformers    >= 0.5.5   && < 1.0
                      , unix-compat     >= 0.5.0   && < 1.0
+                     , zip             >= 1.2.0   && < 2.0
   other-modules:       Paths_hwormhole
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude OverloadedStrings TypeApplications

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -41,6 +41,7 @@ library
                      , conduit-extra   >  1.0.0   && < 2.0
                      , containers      >= 0.5.10  && < 1.0
                      , cryptonite      >= 0.24    && < 1.0
+                     , directory       >= 1.3.3.1 && < 2.0
                      , filepath        >= 1.4.0   && < 2.0
                      , haskeline       >= 0.7.4   && < 1.0
                      , hex             >= 0.1.2   && < 1.0

--- a/src/Transit/Internal/App.hs
+++ b/src/Transit/Internal/App.hs
@@ -187,11 +187,11 @@ receive session code = do
           Right (MagicWormhole.File _ _) -> do
             sendMessageAck conn "not_ok"
             return $ Left (NetworkError (ConnectionError "did not expect a file offer"))
-          Right (MagicWormhole.Directory _ _ _ _ _) ->
+          Right MagicWormhole.Directory {} ->
             return $ Left (NetworkError (UnknownPeerMessage "directory offer is not supported"))
           -- ok, we received the Transit Message, send back a transit message
           Left received ->
-            case (decodeTransitMsg (toS received)) of
+            case decodeTransitMsg (toS received) of
               Left e -> return $ Left (NetworkError e)
               Right transitMsg ->
                 receiveFile conn transitserver appid transitMsg
@@ -205,10 +205,10 @@ app = do
       endpoint = relayEndpoint options
   case cmd options of
     Send tfd ->
-      (liftIO $ MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
+      liftIO (MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
           runApp (sendSession tfd session) env) >>= liftEither
     Receive maybeCode ->
-      (liftIO $ MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
+      liftIO (MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
           runApp (receiveSession maybeCode session) env) >>= liftEither
   where
     getWormholeCode :: MagicWormhole.Session -> [(Text, Text)] -> Maybe Text -> IO Text

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -166,15 +166,15 @@ sendFile conn transitserver appid filepath = do
       case offerResp of
         Left s -> return (Left (NetworkError (OfferError s)))
         Right pathToSend -> do
-          -- 3. send encrypted chunks of N bytes to the peer
+          -- send encrypted chunks of N bytes to the peer
           (txSha256Hash, _) <- C.runConduitRes (sendPipeline pathToSend ep)
-          -- 4. read a record that should contain the transit Ack.
-          --    If ack is not ok or the sha256sum is incorrect, flag an error.
+          -- read a record that should contain the transit Ack.
+          -- If ack is not ok or the sha256sum is incorrect, flag an error.
           rxAckMsg <- receiveAckMessage ep
           closeConnection ep
           case rxAckMsg of
             Right rxSha256Hash ->
-              if (txSha256Hash /= rxSha256Hash)
+              if txSha256Hash /= rxSha256Hash
               then return $ Left (NetworkError (Sha256SumError "sha256 mismatch"))
               else return (Right ())
             Left e -> return $ Left e

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -168,14 +168,15 @@ sendFile conn transitserver appid filepath = do
       case offerResp of
         Left s -> return (Left (NetworkError (OfferError s)))
         Right pathToSend -> do
-          (rxAckMsg, txSha256Hash) <- finally
-                                      (do -- send encrypted records to the peer
-                                          (txSha256Hash, _) <- C.runConduitRes (sendPipeline pathToSend ep)
-                                          -- read a record that should contain the transit Ack.
-                                          -- If ack is not ok or the sha256sum is incorrect, flag an error.
-                                          rxAckMsg <- receiveAckMessage ep
-                                          return (rxAckMsg, txSha256Hash))
-                                      (closeConnection ep)
+          (rxAckMsg, txSha256Hash) <-
+            finally
+            (do -- send encrypted records to the peer
+                (txSha256Hash, _) <- C.runConduitRes (sendPipeline pathToSend ep)
+                -- read a record that should contain the transit Ack.
+                -- If ack is not ok or the sha256sum is incorrect, flag an error.
+                rxAckMsg <- receiveAckMessage ep
+                return (rxAckMsg, txSha256Hash))
+            (closeConnection ep)
           case rxAckMsg of
             Right rxSha256Hash ->
               if txSha256Hash /= rxSha256Hash

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -166,12 +166,14 @@ sendFile conn transitserver appid filepath = do
       case offerResp of
         Left s -> return (Left (NetworkError (OfferError s)))
         Right pathToSend -> do
-          -- send encrypted chunks of N bytes to the peer
-          (txSha256Hash, _) <- C.runConduitRes (sendPipeline pathToSend ep)
-          -- read a record that should contain the transit Ack.
-          -- If ack is not ok or the sha256sum is incorrect, flag an error.
-          rxAckMsg <- receiveAckMessage ep
-          closeConnection ep
+          (rxAckMsg, txSha256Hash) <- finally
+                                      (do -- send encrypted records to the peer
+                                          (txSha256Hash, _) <- C.runConduitRes (sendPipeline pathToSend ep)
+                                          -- read a record that should contain the transit Ack.
+                                          -- If ack is not ok or the sha256sum is incorrect, flag an error.
+                                          rxAckMsg <- receiveAckMessage ep
+                                          return (rxAckMsg, txSha256Hash))
+                                      (closeConnection ep)
           case rxAckMsg of
             Right rxSha256Hash ->
               if txSha256Hash /= rxSha256Hash

--- a/src/Transit/Internal/FileTransfer.hs
+++ b/src/Transit/Internal/FileTransfer.hs
@@ -15,6 +15,8 @@ import qualified Data.Set as Set
 import qualified Data.ByteString.Lazy as BL
 
 import Network.Socket (socketPort, Socket)
+import System.FilePath ((</>))
+import System.Directory (removeFile)
 
 import qualified MagicWormhole
 
@@ -43,7 +45,8 @@ import Transit.Internal.Peer
   , makeAckMessage
   , generateTransitSide
   , sendRecord
-  , receiveRecord)
+  , receiveRecord
+  , unzipInto)
 
 import Transit.Internal.Messages
   ( TransitMsg( Transit, Answer )
@@ -121,14 +124,14 @@ establishSenderTransit conn transitserver appid = do
     Right _ -> return $ Left (NetworkError (UnknownPeerMessage "Could not decode message"))
 
 establishReceiverTransit :: MagicWormhole.EncryptedConnection -> RelayEndpoint -> MagicWormhole.AppID -> TransitMsg -> Socket -> IO (Either Error TransitEndpoint)
-establishReceiverTransit conn transitserver appid (Transit _peerAbilities peerHints) s = do
+establishReceiverTransit conn transitserver appid (Transit _peerAbilities peerHints) socket = do
   let ourRelayHints = buildRelayHints transitserver
   side <- generateTransitSide
   -- combine our relay hints with peer's direct and relay hints
   let allHints = Set.toList (peerHints <> ourRelayHints)
   -- derive transit key
   let transitKey = MagicWormhole.deriveKey conn (transitPurpose appid)
-  transitEndpoint <- race (startServer s) (startClient allHints)
+  transitEndpoint <- race (startServer socket) (startClient allHints)
   let ep = either identity identity transitEndpoint
   case ep of
     Left e -> return (Left (NetworkError e))
@@ -191,24 +194,33 @@ receiveFile conn transitserver appid transit = do
   offerMsg <- receiveWormholeMessage conn
   case Aeson.eitherDecode (toS offerMsg) of
     Left err -> return $ Left (NetworkError (OfferError $ "unable to decode offer msg: " <> toS err))
-    Right (MagicWormhole.File name size) -> do
-      -- TODO: if the file already exist in the current dir, abort
-      -- send an answer message with file_ack.
-      let ans = Answer (FileAck "ok")
-      sendWormholeMessage conn (Aeson.encode ans)
-      -- establish receive transit endpoint
-      endpoint <- establishReceiverTransit conn transitserver appid transit s
-      case endpoint of
-        Left e -> return $ Left e
-        Right ep -> do
-          _ <- finally
-               (do
-                   -- receive and decrypt records (length followed by length
-                   -- sized packets). Also keep track of decrypted size in
-                   -- order to know when to send the file ack at the end.
-                   (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) ep
-                   sendAckMessage ep (toS rxSha256Sum))
-               (closeConnection ep)
-          return $ Right ()
-    Right _ -> return $ Left (NetworkError (UnknownPeerMessage "Directory transfer unsupported"))
+    Right (MagicWormhole.File name size) -> rxFile s name size
+    Right (MagicWormhole.Directory _mode name zipSize _ _uncompressedSize) -> do
+      let zipFile = "/tmp" </> (toS name)
+      _ <- rxFile s zipFile zipSize
+      -- TODO: check if the file system containing the current directory has
+      -- enough space, by checking the uncompressedSize and the free space.
+      _ <- unzipInto (toS name) zipFile
+      Right <$> removeFile zipFile
+    Right _ -> return $ Left (NetworkError (UnknownPeerMessage "cannot decipher the message from peer"))
+    where
+      rxFile socket name size = do
+        -- TODO: if the file already exist in the current dir, abort.
+        -- send an answer message with file_ack.
+        let ans = Answer (FileAck "ok")
+        sendWormholeMessage conn (Aeson.encode ans)
+        -- establish receive transit endpoint
+        endpoint <- establishReceiverTransit conn transitserver appid transit socket
+        case endpoint of
+          Left e -> return $ Left e
+          Right ep -> do
+            _ <- finally
+                 (do
+                     -- receive and decrypt records (length followed by length
+                     -- sized packets). Also keep track of decrypted size in
+                     -- order to know when to send the file ack at the end.
+                     (rxSha256Sum, ()) <- C.runConduitRes $ receivePipeline name (fromIntegral size) ep
+                     sendAckMessage ep (toS rxSha256Sum))
+                 (closeConnection ep)
+            return $ Right ()
 

--- a/src/Transit/Internal/Messages.hs
+++ b/src/Transit/Internal/Messages.hs
@@ -104,7 +104,7 @@ instance FromJSON Ack where
     defaultOptions { sumEncoding = ObjectWithSingleField
                    , constructorTagModifier = camelTo2 '_'}
 
-data Ability = Ability { atype :: AbilityV1 }
+newtype Ability = Ability { atype :: AbilityV1 }
   deriving (Eq, Show, Generic)
 
 instance ToJSON Ability where

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -21,6 +21,7 @@ module Transit.Internal.Peer
   , InvalidHandshake(..)
   , sendRecord
   , receiveRecord
+  , unzipInto
   )
 where
 
@@ -45,7 +46,7 @@ import Crypto.Random (MonadRandom(..))
 import Data.ByteArray.Encoding (convertToBase, Base(Base16))
 import System.IO.Error (IOError)
 import System.Directory.PathWalk (pathWalk)
-import Codec.Archive.Zip (createArchive, CompressionMethod ( Deflate ), mkEntrySelector, packDirRecur)
+import Codec.Archive.Zip (createArchive, withArchive, CompressionMethod ( Deflate ), mkEntrySelector, packDirRecur, unpackInto)
 
 import Transit.Internal.Messages
   ( TransitMsg(..)
@@ -319,7 +320,7 @@ zipDir filePath = do
 
 dirStats :: FilePath -> StateT DirState IO ()
 dirStats filePath = do
-  pathWalk filePath $ \root dirs files -> do
+  pathWalk filePath $ \root _dirs files -> do
       forM_ files $ \file -> do
         size <- liftIO (getFileSize (root </> file))
         (numFiles, totalSize) <- get
@@ -328,3 +329,7 @@ dirStats filePath = do
             getFileSize :: FilePath -> IO FileOffset
             getFileSize file = fileSize <$> getFileStatus file
 
+-- | unzip the given zip file into the especified directory
+-- under current working directory
+unzipInto :: FilePath -> FilePath -> IO ()
+unzipInto dirname zipFilePath = withArchive zipFilePath (unpackInto dirname)

--- a/src/Transit/Internal/Peer.hs
+++ b/src/Transit/Internal/Peer.hs
@@ -37,16 +37,25 @@ import qualified Data.Set as Set
 import Data.Aeson (encode, eitherDecode)
 import Data.Binary.Get (getWord32be, runGet)
 import Data.ByteString.Builder(toLazyByteString, word32BE, byteString)
+import Data.Bits (shiftL)
 import Data.Hex (hex)
 import Data.Text (toLower)
-import System.Posix.Types (FileOffset)
-import System.PosixCompat.Files (getFileStatus, fileSize, isDirectory)
+import System.Posix.Types (FileOffset, FileMode)
+import System.PosixCompat.Files (getFileStatus, fileSize, fileMode, isDirectory)
 import System.FilePath (takeFileName, takeBaseName, dropTrailingPathSeparator, (<.>), (</>))
 import Crypto.Random (MonadRandom(..))
 import Data.ByteArray.Encoding (convertToBase, Base(Base16))
 import System.IO.Error (IOError)
 import System.Directory.PathWalk (pathWalk)
-import Codec.Archive.Zip (createArchive, withArchive, CompressionMethod ( Deflate ), mkEntrySelector, packDirRecur, unpackInto)
+import Codec.Archive.Zip ( createArchive
+                         , withArchive
+                         , CompressionMethod ( Deflate )
+                         , mkEntrySelector
+                         , unEntrySelector
+                         , packDirRecur
+                         , unpackInto
+                         , forEntries
+                         , setExternalFileAttrs)
 
 import Transit.Internal.Messages
   ( TransitMsg(..)
@@ -311,12 +320,21 @@ type DirState = (Int, FileOffset)
 -- the files).
 zipDir :: FilePath -> IO (FilePath, DirState)
 zipDir filePath = do
-  let zipFileName = "/tmp" </> (takeBaseName (dropTrailingPathSeparator filePath)) <.> "zip"
+  let dirName = takeBaseName (dropTrailingPathSeparator filePath)
+  let zipFileName = "/tmp" </> dirName <.> "zip"
   ((_, stats), _) <- concurrently
                      (runStateT (dirStats filePath) (0,0))
-                     (createArchive zipFileName $
-                       packDirRecur Deflate mkEntrySelector filePath)
+                     (do
+                         createArchive zipFileName $
+                           packDirRecur Deflate mkEntrySelector filePath
+                         withArchive zipFileName $ do
+                           forEntries $ \selector -> do
+                             mode <- liftIO $ getFileMode (dirName </> unEntrySelector selector)
+                             setExternalFileAttrs (fromIntegral (mode `shiftL` 16)) selector)
   return (zipFileName, stats)
+    where
+      getFileMode :: FilePath -> IO FileMode
+      getFileMode file = fileMode <$> getFileStatus file
 
 dirStats :: FilePath -> StateT DirState IO ()
 dirStats filePath = do

--- a/src/Transit/Internal/Pipeline.hs
+++ b/src/Transit/Internal/Pipeline.hs
@@ -79,7 +79,7 @@ decryptC key = loop Saltine.zero
       b <- C.await
       case b of
         Nothing -> return ()
-        Just bs -> do
+        Just bs ->
           case decrypt key (CipherText bs) of
             Right (PlainText plainText, nonce) -> do
               let seqNumLE = BS.reverse $ toS $ Saltine.encode seqNum


### PR DESCRIPTION
(This PR sits on top of PR 49)

Known limitations in this version:
- While sending, directory is traversed twice. This may impact the speed, especially while sending large directories.
- While receiving directories, the file permissions are not preserved.

These limitations will be addressed in a future update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/52)
<!-- Reviewable:end -->
