### PR TITLE
new release 0.2.0.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for haskell-magic-wormhole-client
 
+## 0.2.0.0  -- 2018-12-12
+
+* Fix a bug which shows up as a failed hwormhole to hwormhole transfer,
+  at the same time works fine with python magic-wormhole client.
+
 ## 0.1.0.0  -- 2018-12-10
 
 * First version of the haskell port of magic-wormhole client.

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -2,14 +2,14 @@
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                hwormhole
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            magic-wormhole client
 description:         A secure way to send files over the Internet using the magic-wormhole protocol
 license:             GPL-3
 license-file:        LICENSE
-author:              Ramakrishnan Muthukrishnan
-maintainer:          ram@leastauthority.com
-copyright:           (c) 2018 Least Authority TFA Gmbh
+author:              Ramakrishnan Muthukrishnan <ram@leastauthority.com>, Jean-Paul Calderone <jean-paul@leastauthority.com>
+maintainer:          Least Authority TFA GmbH
+copyright:           (c) 2018 Least Authority TFA GmbH
 category:            Network
 build-type:          Simple
 extra-source-files:  ChangeLog.md


### PR DESCRIPTION
Fix a serious bug which broke hwormhole to hwormhole file transfers.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/58)
<!-- Reviewable:end -->
