### PR TITLE
WIP: Initial support to connect via Tor

### DIFF
--- a/cmd/Options.hs
+++ b/cmd/Options.hs
@@ -43,6 +43,9 @@ optionsParser
       Opt.help "Transit relay to use" <>
       Opt.value defaultTransitUrl <>
       Opt.showDefault )
+    <*> Opt.switch
+    ( Opt.long "tor" <>
+      Opt.help "use Tor" )
   where
     -- | Default URL for relay server.
     --

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -43,16 +43,17 @@ library
                      , directory       >= 1.3     && < 2.0
                      , filepath        >= 1.4.0   && < 2.0
                      , haskeline       >= 0.7.4   && < 1.0
-                     , magic-wormhole  >= 0.2.1   && < 1.0
+                     , magic-wormhole  >= 0.3.0   && < 1.0
                      , memory          >= 0.14.15 && < 1.0
                      , mtl             >= 2.2.2   && < 3.0
-                     , network         >= 2.7     && < 3
+                     , network         >= 3.0     && < 4
                      , network-info    >= 0.2.0   && < 1.0
                      , pathwalk        >= 0.3.1.2 && < 1.0
                      , pgp-wordlist    >= 0.1.0.2 && < 1.0
                      , protolude       >= 0.2.1   && < 1.0
                      , random          >= 1.1     && < 2.0
                      , saltine         == 0.1.0.1 && < 1.0
+                     , socks           >= 0.5.6   && < 1.0
                      , spake2          >= 0.4     && < 1.0
                      , temporary       >= 1.3     && < 2.0
                      , text            >= 1.2.1   && < 2.0

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -43,7 +43,7 @@ library
                      , directory       >= 1.3     && < 2.0
                      , filepath        >= 1.4.0   && < 2.0
                      , haskeline       >= 0.7.4   && < 1.0
-                     , magic-wormhole  >= 0.3.0   && < 1.0
+                     , magic-wormhole  >= 0.3.2   && < 1.0
                      , memory          >= 0.14.15 && < 1.0
                      , mtl             >= 2.2.2   && < 3.0
                      , network         >= 3.0     && < 4

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -43,7 +43,7 @@ library
                      , directory       >= 1.3     && < 2.0
                      , filepath        >= 1.4.0   && < 2.0
                      , haskeline       >= 0.7.4   && < 1.0
-                     , magic-wormhole  >= 0.3.2   && < 1.0
+                     , magic-wormhole  >= 0.3.3   && < 1.0
                      , memory          >= 0.14.15 && < 1.0
                      , mtl             >= 2.2.2   && < 3.0
                      , network         >= 3.0     && < 4

--- a/hwormhole.cabal
+++ b/hwormhole.cabal
@@ -103,7 +103,7 @@ test-suite hwormhole-tests
                     , saltine
                     , hwormhole
                     , magic-wormhole
-                    , hedgehog
+                    , hedgehog         >= 0.6     && <1
   other-modules:      ProtocolTests
                     , MessagesTests
                     , PipelineTests

--- a/src/Transit/Internal/App.hs
+++ b/src/Transit/Internal/App.hs
@@ -32,6 +32,7 @@ import Transit.Internal.Conf (Options(..), Command(..))
 import Transit.Internal.Errors (Error(..), CommunicationError(..))
 import Transit.Internal.FileTransfer(MessageType(..), sendFile, receiveFile)
 import Transit.Internal.Peer (sendOffer, receiveOffer, receiveMessageAck, sendMessageAck, decodeTransitMsg)
+import Transit.Internal.Network (connectToTor)
 
 -- | Magic Wormhole transit app environment
 data Env
@@ -229,13 +230,22 @@ app = do
   env <- ask
   let options = config env
       endpoint = relayEndpoint options
-  case cmd options of
-    Send tfd ->
-      liftIO (MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
-          runApp (sendSession tfd session) env) >>= liftEither
-    Receive maybeCode ->
-      liftIO (MagicWormhole.runClient endpoint (appID env) (side env) $ \session ->
-          runApp (receiveSession maybeCode session) env) >>= liftEither
+  sock <- if useTor options
+          then do
+            res <- liftIO $ connectToTor endpoint
+            return $ bimap NetworkError Just res
+          else
+            return (Right Nothing)
+  case sock of
+    Right sock' -> do
+      case cmd options of
+        Send tfd ->
+          liftIO (MagicWormhole.runClient endpoint (appID env) (side env) sock' $ \session ->
+                     runApp (sendSession tfd session) env) >>= liftEither
+        Receive maybeCode ->
+          liftIO (MagicWormhole.runClient endpoint (appID env) (side env) sock' $ \session ->
+                     runApp (receiveSession maybeCode session) env) >>= liftEither
+    Left e -> liftEither (Left e)
   where
     getWormholeCode :: MagicWormhole.Session -> Maybe Text -> IO Text
     getWormholeCode session Nothing = getCode session wordList

--- a/src/Transit/Internal/Conf.hs
+++ b/src/Transit/Internal/Conf.hs
@@ -21,6 +21,8 @@ data Options
   -- ^ Rendezvous server websocket endpoint URL
   , transitUrl :: RelayEndpoint
   -- ^ Transit Relay URL
+  , useTor :: Bool
+  -- ^ Whether to use Tor for all network communication
   } deriving (Eq, Show)
 
 -- | Commands


### PR DESCRIPTION
magic-wormhole library's v0.3.0 adds a parameter to `runClient` function to pass an optional open socket to use to connect to the websocket server. This could be a socks proxy for connecting via Tor. We use it here to connect via tor, if `--tor` is passed in the command line.

This is still a work in progress. Note that Tor support for file/directory transfer is not implemented yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/wormhole-client/67)
<!-- Reviewable:end -->
